### PR TITLE
fix: 테스트 커버리지에 제외된 클래스가 test report에 그대로 노출되는 버그 수정

### DIFF
--- a/.github/workflows/acceptancetest-analyze.yml
+++ b/.github/workflows/acceptancetest-analyze.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - 'develop'
+      - 'main' # TODO : Sonarcloud 테스트용 나중에 지우기
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
 apply from: 'gradle/spring.gradle'
 apply from: 'gradle/lombok.gradle'
 apply from: 'gradle/jacoco.gradle'
+apply from: 'gradle/junit.gradle'
 apply from: 'gradle/sonar.gradle'
 
 group = "${projectGroup}"

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -26,6 +26,14 @@ jacocoTestReport {
     }
     finalizedBy 'jacocoTestCoverageVerification'
     dependsOn test
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: excludeFromCoverage.stream()
+                    .map(s -> s + ".class")
+                    .collect(Collectors.toList()))
+        }))
+    }
 }
 
 jacocoTestCoverageVerification {


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
테스트 커버리지에 제외된 클래스가 test report에 그대로 노출되는 버그 수정

## 🕶️ 어떻게 해결했나요?
- [x] testCodeCoverageReport 생성 과정에서, 제외된 클래스는 생성하지 않도록 수정
- [x] sonarcloud에서 jacoco test code report를 받도록 수정

## 🦀 이슈 넘버
- closes #6 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
