### PR TITLE
chore: PR, Issue기능단위로 자동으로 라벨 붙이는 기능 추가

### DIFF
--- a/.github/workflows/type-labeler.yml
+++ b/.github/workflows/type-labeler.yml
@@ -1,0 +1,62 @@
+name: Type labeler
+
+on:
+  pull_request:
+    types:
+      - opened
+  issues:
+    types:
+      - opened
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: add ✨ feature label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.issues.title, 'feat:') || startsWith(github.event.pull_request.title, 'feat:') }}
+        with:
+          labels: ✨ feature
+
+      - name: add 🐛 bug-fix label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.issues.title, 'fix:') || startsWith(github.event.pull_request.title, 'fix:') }}
+        with:
+          labels: 🐛 bug-fix
+
+      - name: add ♻️ refactor label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.issues.title, 'refactor:') || startsWith(github.event.pull_request.title, 'refactor:') }}
+        with:
+          labels: ♻️ refactor
+
+      - name: add 🎨 style label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.issues.title, 'style:') || startsWith(github.event.pull_request.title, 'style:') }}
+        with:
+          labels: 🎨 style
+
+      - name: add 🍻 chore label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.issues.title, 'chore:') || startsWith(github.event.pull_request.title, 'chore:') }}
+        with:
+          labels: 🍻 chore
+
+      - name: add ✅ test label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.issues.title, 'test:') || startsWith(github.event.pull_request.title, 'test:') }}
+        with:
+          labels: ✅ test
+
+      - name: add 📝 docs label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.issues.title, 'docs:') || startsWith(github.event.pull_request.title, 'docs:') }}
+        with:
+          labels: 📝 docs
+


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
Github PR , Issue에 기능단위로 자동으로 라벨을 붙인다

## 🕶️ 어떻게 해결했나요?
 - [x] 자동으로 라벨링 해주는 ci를 추가했습니다.
 - [x] git convention 에 맞게 라벨링을 하도록 추가했습니다. (PR title과 Issue title에 맞게 자동으로 라벨링이 추가됩니다.)
 	- [x] docs: -> `📝 docs`
 	- [x] test: -> `✅ test`
 	- [x] chore: -> `🍻 chore`
 	- [x] style: -> `🎨 style`
 	- [x] refactor: -> `♻️ refactor`
 	- [x] bug-fix: -> `🐛 bug-fix`
 	- [x] feature: -> `✨ feature`

## 🦀 이슈 넘버
- closes #10 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

## 참고자료
`https://gitmoji.dev` 참조해서 설정했는데, 바꾸고싶은 이모지 있으시면 commet 남겨주세요
