### PR TITLE
refactor: coverage-exclude.asap 경로를 모듈에 맞게 수정

### DIFF
--- a/coverage-exclude.asap
+++ b/coverage-exclude.asap
@@ -1,3 +1,3 @@
-exclude shop/woowasap/asap/app/Application
-exclude shop/woowasap/asap/shop/domain/*
-exclude shop/woowasap/asap/auth/domain/*
+exclude shop/woowasap/Application
+exclude shop/woowasap/shop/domain/*
+exclude shop/woowasap/auth/domain/*


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
coverage-exclude.asap 경로를 모듈에 맞게 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `exclude shop/woowasap/asap/app/Application` -> `exclude shop/woowasap/Application`
- [x] `exclude shop/woowasap/asap/shop/domain/*` -> `exclude shop/woowasap/shop/domain/*`
- [x] `exclude shop/woowasap/asap/auth/domain/*`-> `exclude shop/woowasap/auth/domain/*`

## 🦀 이슈 넘버
- resolve #12 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
