### PR TITLE
test: auth, shop `인수테스트의 validator 추가`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,4 +10,6 @@ dependencies {
     implementation project(':auth:auth-repository')
 
     implementation project(':core:entity')
+
+    testImplementation 'io.rest-assured:rest-assured:5.3.0'
 }

--- a/app/src/test/java/shop/woowasap/BeanScanBaseLocation.java
+++ b/app/src/test/java/shop/woowasap/BeanScanBaseLocation.java
@@ -1,0 +1,5 @@
+package shop.woowasap;
+
+public class BeanScanBaseLocation {
+
+}

--- a/app/src/test/java/shop/woowasap/accept/AcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/AcceptanceTest.java
@@ -1,0 +1,25 @@
+package shop.woowasap.accept;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ContextConfiguration;
+import shop.woowasap.BeanScanBaseLocation;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@ContextConfiguration(classes = BeanScanBaseLocation.class)
+abstract class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setPort() {
+        RestAssured.port = port;
+    }
+}

--- a/app/src/test/java/shop/woowasap/accept/support/valid/AuthValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/AuthValidator.java
@@ -1,0 +1,27 @@
+package shop.woowasap.accept.support.valid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import shop.woowasap.mock.dto.SignUpResponse;
+
+public final class AuthValidator {
+
+    private AuthValidator() {
+    }
+
+    public static void assertLogin(ExtractableResponse<Response> result) {
+        HttpValidator.assertOk(result);
+
+        String token = result.jsonPath().getString("token");
+        assertThat(token).isNotBlank();
+    }
+
+    public static void assertSigned(ExtractableResponse<Response> result, SignUpResponse expected) {
+        HttpValidator.assertCreated(result);
+
+        SignUpResponse resultResponse = result.as(SignUpResponse.class);
+        assertThat(resultResponse).isEqualTo(expected);
+    }
+}

--- a/app/src/test/java/shop/woowasap/accept/support/valid/HttpValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/HttpValidator.java
@@ -1,0 +1,21 @@
+package shop.woowasap.accept.support.valid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+
+public final class HttpValidator {
+
+    private HttpValidator() {
+    }
+
+    public static void assertOk(ExtractableResponse<Response> result) {
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.SC_OK);
+    }
+
+    public static void assertCreated(ExtractableResponse<Response> result) {
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.SC_CREATED);
+    }
+}

--- a/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
@@ -1,0 +1,56 @@
+package shop.woowasap.accept.support.valid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import shop.woowasap.mock.dto.ProductsResponse;
+import shop.woowasap.mock.dto.ProductsResponse.Product;
+
+public final class ShopValidator {
+
+    private ShopValidator() {
+    }
+
+    public static void assertProductRegistered(ExtractableResponse<Response> result) {
+        HttpValidator.assertCreated(result);
+
+        assertThat(result.header("Location")).isNotBlank();
+    }
+
+    public static void assertProductUpdated(ExtractableResponse<Response> result) {
+        HttpValidator.assertOk(result);
+    }
+
+    public static void assertProductsFound(ExtractableResponse<Response> result,
+        ProductsResponse expected) {
+        HttpValidator.assertOk(result);
+
+        ProductsResponse resultResponse = result.as(ProductsResponse.class);
+        assertProducts(resultResponse, expected);
+    }
+
+    private static void assertProducts(ProductsResponse result, ProductsResponse expected) {
+        assertThat(result.page()).isEqualTo(expected.page());
+        assertThat(result.totalPage()).isEqualTo(expected.totalPage());
+
+        assertProductsExceptId(result, expected);
+    }
+
+    private static void assertProductsExceptId(ProductsResponse result, ProductsResponse expected) {
+        List<Product> resultList = result.products();
+        List<ProductsResponse.Product> expectedList = expected.products();
+        assertThat(resultList).hasSize(expectedList.size());
+
+        for (int i = 0; i < resultList.size(); i++) {
+            ProductsResponse.Product resultElement = resultList.get(i);
+            ProductsResponse.Product expectedElement = expectedList.get(i);
+
+            assertThat(resultElement.name()).isEqualTo(expectedElement.name());
+            assertThat(resultElement.price()).isEqualTo(expectedElement.price());
+            assertThat(resultElement.endTime()).isEqualTo(expectedElement.endTime());
+            assertThat(resultElement.startTime()).isEqualTo(expectedElement.startTime());
+        }
+    }
+}

--- a/app/src/test/java/shop/woowasap/mock/dto/ProductsResponse.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/ProductsResponse.java
@@ -1,0 +1,13 @@
+package shop.woowasap.mock.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ProductsResponse(List<Product> products, int page, int totalPage) {
+
+    public record Product(long productId, String name, long price, LocalDateTime startTime,
+                                  LocalDateTime endTime) {
+
+    }
+
+}

--- a/app/src/test/java/shop/woowasap/mock/dto/SignUpResponse.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/SignUpResponse.java
@@ -1,0 +1,5 @@
+package shop.woowasap.mock.dto;
+
+public record SignUpResponse(String userId, String password) {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
auth, shop 인수테스트의 validator를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 인증 API의 결과를 검증하는 `auth validator` 를 추가했습니다.
- [x] 상점 API의 결과를 검증하는 `shop validator`를 추가했습니다.
- [x] 인증, 상점 검증에 필요한 dto를 `test...mock.dto` 패키지에 생성해놨습니다. 
		**나중에, dto구현할때 mock.dto 구조 그대로 가져가서 사용하시거나, 직접 만드신 dto로 import 변경해주세요**
- [x] 인수테스트의 base가 되는 `AcceptanceTest` 를 생성했습니다.
``` java
// 사용예시
class ShopAcceptanceTest extends AcceptanceTest {
	// ...
}
```
- [x] HttpStatusCode를 검증하는 `Http validator` 를 추가했습니다.

## 🦀 이슈 넘버
- resolve #29 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
