### PR TITLE
test: auth, shop `인수테스트 API supporter 추가`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,4 +10,6 @@ dependencies {
     implementation project(':auth:auth-repository')
 
     implementation project(':core:entity')
+
+    testImplementation 'io.rest-assured:rest-assured:5.3.0'
 }

--- a/app/src/test/java/shop/woowasap/accept/support/api/AuthApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/AuthApiSupporter.java
@@ -1,0 +1,40 @@
+package shop.woowasap.accept.support.api;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import shop.woowasap.mock.dto.LoginRequest;
+import shop.woowasap.mock.dto.SignUpRequest;
+
+public final class AuthApiSupporter {
+
+    private static final String API_VERSION = "/v1";
+
+    private AuthApiSupporter() {
+    }
+
+    public static ExtractableResponse<Response> login(LoginRequest loginRequest) {
+        return given().log().all()
+            .contentType(JSON)
+            .accept(JSON)
+            .body(loginRequest)
+            .when().log().all()
+            .post(API_VERSION + "/login")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> signUp(SignUpRequest signUpRequest) {
+        return given().log().all()
+            .contentType(JSON)
+            .accept(JSON)
+            .body(signUpRequest)
+            .when().log().all()
+            .post(API_VERSION + "/signup")
+            .then().log().all()
+            .extract();
+    }
+
+}

--- a/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
@@ -1,0 +1,65 @@
+package shop.woowasap.accept.support.api;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpHeaders;
+import shop.woowasap.mock.dto.RegisterProductRequest;
+import shop.woowasap.mock.dto.UpdateProductRequest;
+
+public final class ShopApiSupporter {
+
+    private static final String API_VERSION = "/v1";
+
+    private ShopApiSupporter() {
+    }
+
+    public static ExtractableResponse<Response> registerProduct(String token,
+        RegisterProductRequest registerProductRequest) {
+
+        return given().log().all()
+            .contentType(JSON)
+            .accept(JSON)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .body(registerProductRequest)
+            .when().log().all()
+            .post(API_VERSION + "/products")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> updateProduct(String token,
+        UpdateProductRequest updateProductRequest) {
+
+        return given().log().all()
+            .contentType(JSON)
+            .accept(JSON)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .body(updateProductRequest)
+            .when().log().all()
+            .put(API_VERSION + "/products")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> getAllProducts() {
+        return given().log().all()
+            .accept(JSON)
+            .when().log().all()
+            .get(API_VERSION + "/products")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> getRegisteredProducts(String token, long userId) {
+        return given().log().all()
+            .accept(JSON)
+            .when().log().all()
+            .get(API_VERSION + "/products/{user-id}", userId)
+            .then().log().all()
+            .extract();
+    }
+
+}

--- a/app/src/test/java/shop/woowasap/mock/dto/LoginRequest.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/LoginRequest.java
@@ -1,0 +1,4 @@
+package shop.woowasap.mock.dto;
+
+public record LoginRequest(String userId, String password) {
+}

--- a/app/src/test/java/shop/woowasap/mock/dto/RegisterProductRequest.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/RegisterProductRequest.java
@@ -1,0 +1,8 @@
+package shop.woowasap.mock.dto;
+
+import java.time.LocalDateTime;
+
+public record RegisterProductRequest(String name, String description, String price, int quantity,
+                                     LocalDateTime startTime, LocalDateTime endTime) {
+
+}

--- a/app/src/test/java/shop/woowasap/mock/dto/SignUpRequest.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/SignUpRequest.java
@@ -1,0 +1,4 @@
+package shop.woowasap.mock.dto;
+
+public record SignUpRequest(String userId, String password) {
+}

--- a/app/src/test/java/shop/woowasap/mock/dto/UpdateProductRequest.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/UpdateProductRequest.java
@@ -1,0 +1,8 @@
+package shop.woowasap.mock.dto;
+
+import java.time.LocalDateTime;
+
+public record UpdateProductRequest(String name, String description, String price, int quantity,
+                                  LocalDateTime startTime, LocalDateTime endTime) {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
auth, shop api의 인수테스트 API supporter를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] shop api를 호출하는 `ShopApiSupporter` 를 추가했습니다.
- [x] auth api를 호출하는 `AuthApiSupporter` 를 추가했습니다.
- [x] auth, shop api 요청에 필요한 dto를 test...mock.dto 패키지에 생성해놨습니다.
		**나중에, dto구현할때 mock.dto 구조 그대로 가져가서 사용하시거나, 직접 만드신 dto로 import 변경해주세요**

## 🦀 이슈 넘버
- resolve #29

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
