### PR TITLE
fix: Infer CI 에서 `accept test` 제외

### DIFF
--- a/Dockerfile-Infer
+++ b/Dockerfile-Infer
@@ -26,4 +26,4 @@ RUN tar -xf infer-linux64-$INFER_VERSION.tar.xz && \
 
 ENV PATH /infer/bin:${PATH}
 
-ENTRYPOINT ["infer", "run", "--fail-on-issue", "--", "./gradlew", "test"]
+ENTRYPOINT ["infer", "run", "--fail-on-issue", "--", "./gradlew", "test", "--exclude-task", "app:test"]


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
Infer CI에서 accept test 를 제외했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] Dockerfile-Infer 에서, `--exclude-task app:test`

## 🦀 이슈 넘버
- close #38 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
