### PR TITLE
test: 상품 수정 인수테스트 수정 및 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
@@ -2,18 +2,22 @@ package shop.woowasap.accept;
 
 import static shop.woowasap.accept.product.ProductFixture.forbiddenUserLoginRequest;
 import static shop.woowasap.accept.product.ProductFixture.loginRequest;
+import static shop.woowasap.accept.product.ProductFixture.registerProductRequest;
 import static shop.woowasap.accept.product.ProductFixture.updateProductRequest;
+import static shop.woowasap.accept.support.api.AuthApiSupporter.login;
+import static shop.woowasap.accept.support.api.ShopApiSupporter.registerProduct;
 import static shop.woowasap.accept.support.valid.HttpValidator.assertForbidden;
+import static shop.woowasap.accept.support.valid.HttpValidator.assertNotFound;
 import static shop.woowasap.accept.support.valid.HttpValidator.assertOk;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import shop.woowasap.accept.support.api.AuthApiSupporter;
 import shop.woowasap.accept.support.api.ShopApiSupporter;
 import shop.woowasap.mock.dto.LoginRequest;
 import shop.woowasap.mock.dto.LoginResponse;
+import shop.woowasap.mock.dto.RegisterProductRequest;
 import shop.woowasap.mock.dto.UpdateProductRequest;
 
 @DisplayName("Product 인수테스트")
@@ -24,12 +28,22 @@ class ProductAcceptanceTest extends AcceptanceTest {
     void updateProduct() {
         // given
         final LoginRequest loginRequest = loginRequest();
-        final String accessToken = AuthApiSupporter.login(loginRequest)
+        final String accessToken = login(loginRequest)
             .as(LoginResponse.class).token();
+
+        final RegisterProductRequest registerProductRequest = registerProductRequest();
+        final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
+            registerProductRequest);
+
+        long productId = Long.parseLong(registerResponse
+                            .header("Location")
+                            .split("/")[4]);
+
         final UpdateProductRequest updateProductRequest = updateProductRequest();
 
         // when
         ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
+            productId,
             updateProductRequest);
 
         // then
@@ -41,16 +55,47 @@ class ProductAcceptanceTest extends AcceptanceTest {
     void updateProductWithForbidden() {
         // given
         final LoginRequest forbiddenUserLoginRequest = forbiddenUserLoginRequest();
-        final String accessToken = AuthApiSupporter.login(forbiddenUserLoginRequest)
+        final String accessToken = login(forbiddenUserLoginRequest)
             .as(LoginResponse.class).token();
+
+        final RegisterProductRequest registerProductRequest = registerProductRequest();
+        final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
+            registerProductRequest);
+
+        long productId = Long.parseLong(registerResponse
+            .header("Location")
+            .split("/")[4]);
+
         final UpdateProductRequest updateProductRequest = updateProductRequest();
 
         // when
         ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
+            productId,
             updateProductRequest);
 
         // then
         assertForbidden(response);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품을 수정하려고 하는경우 NOTFOUND 응답을 받는다.")
+    void updateProductWithNotFound() {
+        // given
+        final LoginRequest forbiddenUserLoginRequest = forbiddenUserLoginRequest();
+        final String accessToken = login(forbiddenUserLoginRequest)
+            .as(LoginResponse.class).token();
+
+        final long invalidProductId = 123;
+
+        final UpdateProductRequest updateProductRequest = updateProductRequest();
+
+        // when
+        ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
+            invalidProductId,
+            updateProductRequest);
+
+        // then
+        assertNotFound(response);
     }
 
 }

--- a/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
@@ -35,7 +35,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
             registerProductRequest);
 
-        long productId = Long.parseLong(registerResponse
+        final long productId = Long.parseLong(registerResponse
                             .header("Location")
                             .split("/")[4]);
 
@@ -62,7 +62,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
             registerProductRequest);
 
-        long productId = Long.parseLong(registerResponse
+        final long productId = Long.parseLong(registerResponse
             .header("Location")
             .split("/")[4]);
 

--- a/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
@@ -31,6 +31,7 @@ public final class ShopApiSupporter {
     }
 
     public static ExtractableResponse<Response> updateProduct(String token,
+        long productId,
         UpdateProductRequest updateProductRequest) {
 
         return given().log().all()
@@ -39,7 +40,7 @@ public final class ShopApiSupporter {
             .header(HttpHeaders.AUTHORIZATION, token)
             .body(updateProductRequest)
             .when().log().all()
-            .put(API_VERSION + "/products")
+            .put(API_VERSION + "/products/{product-id}", productId)
             .then().log().all()
             .extract();
     }

--- a/app/src/test/java/shop/woowasap/accept/support/valid/HttpValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/HttpValidator.java
@@ -22,4 +22,8 @@ public final class HttpValidator {
     public static void assertForbidden(ExtractableResponse<Response> result) {
         assertThat(result.statusCode()).isEqualTo(HttpStatus.SC_FORBIDDEN);
     }
+
+    public static void assertNotFound(ExtractableResponse<Response> result) {
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+    }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
존재하지 않는 상품에 대한 수정을 요청할 경우의 테스트를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 상품 수정 요청 전, 상품 등록 요청 추가
- [x] 존재하지 않는 상품에 대한 수정 요청 시, NOTFOUND를 응답

## 🦀 이슈 넘버
- resolve #27 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
