### PR TITLE
feat: snowflake id generator 생성

### DIFF
--- a/auth/auth-service/build.gradle
+++ b/auth/auth-service/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    implementation project(':core:id-gen')
+
     implementation project(':auth:auth-domain')
     implementation project(':auth:auth-repository')
 }

--- a/core/id-gen/build.gradle
+++ b/core/id-gen/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'com.github.f4b6a3:tsid-creator:5.2.4' // MIT LICENSE
+
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}

--- a/core/id-gen/src/main/java/shop/woowasap/core/id/api/IdGenerator.java
+++ b/core/id-gen/src/main/java/shop/woowasap/core/id/api/IdGenerator.java
@@ -1,0 +1,6 @@
+package shop.woowasap.core.id.api;
+
+public interface IdGenerator {
+
+    long generate();
+}

--- a/core/id-gen/src/main/java/shop/woowasap/core/id/snowflake/SnowflakeIdGenerator.java
+++ b/core/id-gen/src/main/java/shop/woowasap/core/id/snowflake/SnowflakeIdGenerator.java
@@ -1,0 +1,29 @@
+package shop.woowasap.core.id.snowflake;
+
+
+import com.github.f4b6a3.tsid.TsidFactory;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import shop.woowasap.core.id.api.IdGenerator;
+
+@Component
+final class SnowflakeIdGenerator implements IdGenerator {
+
+    private static final int CONCURRENT_THREAD_THRESHOLD = 256;
+    private static final Map<Long, TsidFactory> SNOWFLAKE_THREAD_FACTORY = new HashMap<>();
+
+    static {
+        for (int threadId = 0; threadId < CONCURRENT_THREAD_THRESHOLD; threadId++) {
+            SNOWFLAKE_THREAD_FACTORY.put((long) threadId, TsidFactory.newInstance256(threadId));
+        }
+    }
+
+    @Override
+    public long generate() {
+        long currentThreadId = Thread.currentThread().getId();
+        return SNOWFLAKE_THREAD_FACTORY.get(currentThreadId % CONCURRENT_THREAD_THRESHOLD)
+            .create()
+            .toLong();
+    }
+}

--- a/core/id-gen/src/test/java/shop/woowasap/core/id/snowflake/SnowflakeIdGeneratorTest.java
+++ b/core/id-gen/src/test/java/shop/woowasap/core/id/snowflake/SnowflakeIdGeneratorTest.java
@@ -1,0 +1,84 @@
+package shop.woowasap.core.id.snowflake;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.waitAtMost;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import shop.woowasap.core.id.api.IdGenerator;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("SnowflakeIdGenerator 클래스")
+@ContextConfiguration(classes = SnowflakeIdGenerator.class)
+class SnowflakeIdGeneratorTest {
+
+    @Autowired
+    private IdGenerator idGenerator;
+
+    @Nested
+    @DisplayName("generate 메소드는")
+    class generateMethod {
+
+        @Test
+        @DisplayName("long id를 생성한다")
+        void createLongTypeId() {
+            // given
+            final Class<Long> expectedType = Long.class;
+
+            // when
+            long id = idGenerator.generate();
+
+            // then
+            assertThat(id).isInstanceOf(expectedType);
+        }
+
+        @Test
+        @DisplayName("멀티스레드 환경에서 모두 다른 id가 생성됨을 보장한다")
+        void createAllDifferentIdOnMultiThread() {
+            // given
+            final int expectedGeneratedIdCount = 10000;
+            final ExecutorService executorService = Executors.newFixedThreadPool(256);
+            final List<Callable<Long>> idGenerateThreads = idGenerateThreads(expectedGeneratedIdCount);
+
+            // when & then
+            waitAtMost(ofSeconds(10))
+                .until(() -> generateId(executorService, idGenerateThreads).size(),
+                    Matchers.equalTo(expectedGeneratedIdCount));
+        }
+
+        private List<Callable<Long>> idGenerateThreads(int actorCount) {
+            final List<Callable<Long>> actors = new ArrayList<>();
+            for (int i = 0; i < actorCount; i++) {
+                actors.add(() -> idGenerator.generate());
+            }
+            return actors;
+        }
+
+        private Set<Long> generateId(ExecutorService executorService,
+            List<Callable<Long>> callableList) throws InterruptedException, ExecutionException {
+
+            final Set<Long> generatedId = new HashSet<>();
+            final List<Future<Long>> futureList = executorService.invokeAll(callableList);
+            for (Future<Long> future : futureList) {
+                generatedId.add(future.get());
+            }
+            return generatedId;
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,3 +28,6 @@ include 'auth:auth-repository'
 
 include 'core'
 include 'core:entity'
+include 'core:id-gen'
+findProject(':core:id-gen')?.name = 'id-gen'
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,5 +29,4 @@ include 'auth:auth-repository'
 include 'core'
 include 'core:entity'
 include 'core:id-gen'
-findProject(':core:id-gen')?.name = 'id-gen'
 

--- a/shop/shop-service/build.gradle
+++ b/shop/shop-service/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    implementation project(':core:id-gen')
+
     implementation project(':shop:shop-domain')
     implementation project(':shop:shop-repository')
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
**Snowflake Id generator** 를 부착했습니다.

구현체는 Tsid 인데, 그냥 snowflake 알고리즘을 구현한거라 통용되는 snowflake로 부를게요!

**Snowflake?**

```
(___________) (______) (__________)
( timestamp ) ( node ) (sequential)
```
로 이루어져있고, node를 장비의 고유번호 (혹은 우리가 지정) 해서 서버 혹은 스레드마다 다른 값이 생성됨을 보장합니다. 

멀티스레드에서 이거보다 좋은 id 생성기를 찾지는 못했는데, 찾으면 추후에 변경하면 될거같아요. 
추상화 해놔서 구현체만 갈아치우면 됩니다!

## 🕶️ 어떻게 해결했나요?
- [x]  256개의 스레드에 대해서, 동시에 중복없는 Id가 생성되도록 만들었습니다.
		(1024, 4096 까지 가능은 한데, 그럼 성능이 내려가서 256으로 만들었습니다. 나중에 저희 서비스가 동접 256뚫으면 늘리면 될듯 합니다)
- [x] 10000개의 클라이언트, 255개의 thread에 대해서, 동시성 테스트를 진행했고 중복 id가 생성되지 않는걸 확인했습니다.
		_이 부분은 테스트 참조해주세요_
- [x] IdGenerator 부분은 인터페이스로 추상화를 했는데, 회의 후, 다른 Id generator를 사용하거나 할때 유연하게 변경하기 위함입니다.

## 🦀 이슈 넘버
- close #30 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

## 참고자료
[snowflake?](https://en.wikipedia.org/wiki/Snowflake_ID)

