### PR TITLE
fix: ShopValidator의 softAssertions 수정

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
@@ -37,12 +37,12 @@ public final class ShopValidator {
         ProductResponse resultProduct = result.as(ProductResponse.class);
 
         SoftAssertions.assertSoftly(softAssertions -> {
-            assertThat(resultProduct.description()).isEqualTo(expected.description());
-            assertThat(resultProduct.name()).isEqualTo(expected.name());
-            assertThat(resultProduct.endTime()).isEqualTo(expected.endTime());
-            assertThat(resultProduct.startTime()).isEqualTo(expected.startTime());
-            assertThat(resultProduct.price()).isEqualTo(expected.price());
-            assertThat(resultProduct.quantity()).isEqualTo(expected.quantity());
+            softAssertions.assertThat(resultProduct.description()).isEqualTo(expected.description());
+            softAssertions.assertThat(resultProduct.name()).isEqualTo(expected.name());
+            softAssertions.assertThat(resultProduct.endTime()).isEqualTo(expected.endTime());
+            softAssertions.assertThat(resultProduct.startTime()).isEqualTo(expected.startTime());
+            softAssertions.assertThat(resultProduct.price()).isEqualTo(expected.price());
+            softAssertions.assertThat(resultProduct.quantity()).isEqualTo(expected.quantity());
         });
     }
 


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
ShopValidator의 softAssertions이 잘못 사용되고있는부분 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] Assertions.assertThat -> softAssertions.assertThat 으로 수정

## 🦀 이슈 넘버
- resolve #46 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
