### PR TITLE
chore: `Infer CI` 가 main, develop release PR 에서만 수행되도록 수정

### DIFF
--- a/.github/workflows/infer-analyze.yml
+++ b/.github/workflows/infer-analyze.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
       - 'develop'
-      - '**/base-**'
+      - 'release/*'
 
 jobs:
   build:


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
Infer CI가 main, develop, release로 가는 PR에만 수행되도록 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] Infer CI workflow `on 절` 수정

## 🦀 이슈 넘버
- close #67 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
