### PR TITLE
test: 특정 상품 조회 인수테스트를 추가한다

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
@@ -63,4 +63,12 @@ public final class ShopApiSupporter {
             .extract();
     }
 
+    public static ExtractableResponse<Response> getProduct(long productId) {
+        return given().log().all()
+            .accept(JSON)
+            .when().log().all()
+            .get(API_VERSION + "/products/details/{product-id}", productId)
+            .then().log().all()
+            .extract();
+    }
 }

--- a/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
@@ -67,7 +67,7 @@ public final class ShopApiSupporter {
         return given().log().all()
             .accept(JSON)
             .when().log().all()
-            .get(API_VERSION + "/products/details/{product-id}", productId)
+            .get(API_VERSION + "/products/{product-id}", productId)
             .then().log().all()
             .extract();
     }

--- a/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
+++ b/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
@@ -3,6 +3,7 @@ package shop.woowasap.accept.support.fixture;
 import java.time.LocalDateTime;
 import shop.woowasap.mock.dto.LoginRequest;
 import shop.woowasap.shop.app.api.request.RegisterProductRequest;
+import shop.woowasap.shop.app.api.response.ProductResponse;
 
 public class ProductFixture {
 
@@ -15,6 +16,7 @@ public class ProductFixture {
     public static final long QUANTITY = 10L;
     public static final LocalDateTime START_TIME = LocalDateTime.of(2023, 8, 5, 12, 30);
     public static final LocalDateTime END_TIME = LocalDateTime.of(2023, 8, 5, 14, 30);
+    public static final long UNKNOWN_ID = 1L;
 
     public static LoginRequest loginRequest() {
         return new LoginRequest(USER_ID, PASSWORD);
@@ -26,5 +28,12 @@ public class ProductFixture {
 
     public static RegisterProductRequest registerProductRequest() {
         return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, START_TIME, END_TIME);
+    }
+
+    public static ProductResponse productResponse(RegisterProductRequest registerProductRequest) {
+        return new ProductResponse(UNKNOWN_ID, registerProductRequest.name(),
+            registerProductRequest.description(), registerProductRequest.price(),
+            registerProductRequest.quantity(), registerProductRequest.startTime(),
+            registerProductRequest.endTime());
     }
 }

--- a/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
@@ -5,10 +5,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import shop.woowasap.mock.dto.ProductsResponse;
 import shop.woowasap.mock.dto.ProductsResponse.Product;
+import shop.woowasap.shop.app.api.response.ProductResponse;
 
 public final class ShopValidator {
+
+    private static final RecursiveComparisonConfiguration IGNORE_ID_COMPARISON = RecursiveComparisonConfiguration.builder()
+        .withIgnoredFields("id")
+            .build();
 
     private ShopValidator() {
     }
@@ -52,5 +59,12 @@ public final class ShopValidator {
             assertThat(resultElement.endTime()).isEqualTo(expectedElement.endTime());
             assertThat(resultElement.startTime()).isEqualTo(expectedElement.startTime());
         }
+    }
+
+    public static void assertProduct(ExtractableResponse<Response> result,
+        ProductResponse expected) {
+        HttpValidator.assertOk(result);
+
+        assertThat(result).usingRecursiveComparison(IGNORE_ID_COMPARISON).isEqualTo(expected);
     }
 }

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/app/api/response/ProductResponse.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/app/api/response/ProductResponse.java
@@ -1,0 +1,8 @@
+package shop.woowasap.shop.app.api.response;
+
+import java.time.LocalDateTime;
+
+public record ProductResponse(long productId, String name, String description, String price,
+                              long quantity, LocalDateTime startTime, LocalDateTime endTime) {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
특정 상품 조회 인수테스트를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 저장되어있는 특정 상품을 조회할경우, 상품의 정보응답 인수 테스트 추가
- [x] productId에 해당하는 상품을 찾을 수 없다면, 400 BadRequest가 응답 인수 테스트 추가

## 🦀 이슈 넘버
- resolve #46 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
