### PR TITLE
feat: `/products/{product-id}` API handler 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
@@ -89,7 +89,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final RegisterProductRequest registerProductRequest = ProductFixture.registerProductRequest();
 
         ShopApiSupporter.registerProduct(token, registerProductRequest);
-        ProductsResponse productsResponse = ShopApiSupporter.getAllProducts()
+        final ProductsResponse productsResponse = ShopApiSupporter.getAllProducts()
             .as(ProductsResponse.class);
 
         final long anyProductId = productsResponse.products().get(0).productId();
@@ -106,7 +106,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
     @DisplayName("productId에 해당하는 상품을 찾을 수 없다면, 400 BadRequest가 응답된다.")
     void returnBadRequestWhenCannotFoundProduct() {
         // given
-        final long notFoundProductId = 0L;
+        final long notFoundProductId = 123L;
 
         // when
         ExtractableResponse<Response> result = ShopApiSupporter.getProduct(notFoundProductId);

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
@@ -18,7 +18,7 @@ import shop.woowasap.shop.app.exception.CannotFindProductException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/admin/products")
-public class ProductController {
+public class ProductAdminController {
 
     private final ProductUseCase productUseCase;
 

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductController.java
@@ -1,0 +1,26 @@
+package shop.woowasap.shop.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.woowasap.shop.app.api.ProductUseCase;
+import shop.woowasap.shop.app.api.response.ProductResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/products")
+public class ProductController {
+
+    private final ProductUseCase productUseCase;
+
+    @GetMapping("/{product-id}")
+    public ResponseEntity<ProductResponse> getByProductId(
+        @PathVariable("product-id") long productId) {
+        
+        return ResponseEntity.ok(productUseCase.getById(productId));
+    }
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
`/products/{product-id}` API handler를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 기존의 ProductController를 ProductAdminController로 이름 변경
- [x] `/products/{product-id}` 요청을 받는 ProductController 생성
- [x] 인수테스트 not found product id 변경

## 🦀 이슈 넘버
- resolve #46

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
