### PR TITLE
test: 상품 전체 조회 인수테스트

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
@@ -9,7 +9,6 @@ import static shop.woowasap.accept.support.valid.ShopValidator.assertProductRegi
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -87,24 +86,14 @@ class ProductAcceptanceTest extends AcceptanceTest {
         // given
         final String accessToken = "Token";
 
-        final RegisterProductRequest invalidRegisterProductRequest1 = ProductFixture.registerProductRequestWithTime(
-            LocalDateTime.now().minusHours(10),
-            LocalDateTime.now().minusHours(5));
+        final RegisterProductRequest invalidRegisterProductRequest = ProductFixture.registerInvalidProductRequest();
+        final RegisterProductRequest validRegisterProductRequest = ProductFixture.registerValidProductRequest();
 
-        final RegisterProductRequest validRegisterProductRequest1 = ProductFixture.registerProductRequestWithTime(
-            LocalDateTime.now().plusHours(10),
-            LocalDateTime.now().plusHours(15));
+        registerProduct(accessToken, invalidRegisterProductRequest);
+        registerProduct(accessToken, validRegisterProductRequest);
+        registerProduct(accessToken, validRegisterProductRequest);
 
-        final RegisterProductRequest validRegisterProductRequest2 = ProductFixture.registerProductRequestWithTime(
-            LocalDateTime.now().plusHours(15),
-            LocalDateTime.now().plusHours(120));
-
-        registerProduct(accessToken, invalidRegisterProductRequest1);
-        registerProduct(accessToken, validRegisterProductRequest1);
-        registerProduct(accessToken, validRegisterProductRequest2);
-
-        final List<RegisterProductRequest> registerProductRequests = List.of(validRegisterProductRequest1,
-            validRegisterProductRequest2);
+        final List<RegisterProductRequest> registerProductRequests = List.of(validRegisterProductRequest, validRegisterProductRequest);
 
         // when
         final ExtractableResponse<Response> response = ShopApiSupporter.getAllProducts();

--- a/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
@@ -40,7 +40,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final UpdateProductRequest updateProductRequest = updateProductRequest();
 
         // when
-        ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
+        final ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
             productId,
             updateProductRequest);
 
@@ -59,7 +59,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final UpdateProductRequest updateProductRequest = updateProductRequest();
 
         // when
-        ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
+        final ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
             invalidProductId,
             updateProductRequest);
 
@@ -87,15 +87,15 @@ class ProductAcceptanceTest extends AcceptanceTest {
         // given
         final String accessToken = "Token";
 
-        RegisterProductRequest invalidRegisterProductRequest1 = ProductFixture.registerProductRequestWithTime(
+        final RegisterProductRequest invalidRegisterProductRequest1 = ProductFixture.registerProductRequestWithTime(
             LocalDateTime.now().minusHours(10),
             LocalDateTime.now().minusHours(5));
 
-        RegisterProductRequest validRegisterProductRequest1 = ProductFixture.registerProductRequestWithTime(
+        final RegisterProductRequest validRegisterProductRequest1 = ProductFixture.registerProductRequestWithTime(
             LocalDateTime.now().plusHours(10),
             LocalDateTime.now().plusHours(15));
 
-        RegisterProductRequest validRegisterProductRequest2 = ProductFixture.registerProductRequestWithTime(
+        final RegisterProductRequest validRegisterProductRequest2 = ProductFixture.registerProductRequestWithTime(
             LocalDateTime.now().plusHours(15),
             LocalDateTime.now().plusHours(120));
 
@@ -103,12 +103,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
         registerProduct(accessToken, validRegisterProductRequest1);
         registerProduct(accessToken, validRegisterProductRequest2);
 
-        List<RegisterProductRequest> registerProductRequests = List.of(validRegisterProductRequest1,
+        final List<RegisterProductRequest> registerProductRequests = List.of(validRegisterProductRequest1,
             validRegisterProductRequest2);
 
         // when
-        ExtractableResponse<Response> response = ShopApiSupporter.getAllProducts();
-        ProductsResponse expected = ProductFixture.productsResponse(registerProductRequests);
+        final ExtractableResponse<Response> response = ShopApiSupporter.getAllProducts();
+        final ProductsResponse expected = ProductFixture.productsResponse(registerProductRequests);
 
         // then
         ShopValidator.assertProductsFound(response, expected);

--- a/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
+++ b/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
@@ -19,6 +19,8 @@ public class ProductFixture {
     public static final long QUANTITY = 10L;
     public static final LocalDateTime START_TIME = LocalDateTime.of(2023, 8, 5, 12, 30);
     public static final LocalDateTime END_TIME = LocalDateTime.of(2023, 8, 5, 14, 30);
+    public static final LocalDateTime INFINITE_START_TIME = LocalDateTime.of(99_999, 12, 31, 23, 59);
+    public static final LocalDateTime INFINITE_END_TIME = LocalDateTime.of(999_999, 12, 31, 23, 59);
     public static final long UNKNOWN_ID = 1L;
     public static final int PAGE = 1;
     public static final int TOTAL_PAGE = 1;
@@ -36,9 +38,12 @@ public class ProductFixture {
         return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, START_TIME, END_TIME);
     }
 
-    public static RegisterProductRequest registerProductRequestWithTime(LocalDateTime startTime,
-        LocalDateTime endTime) {
-        return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, startTime, endTime);
+    public static RegisterProductRequest registerValidProductRequest() {
+        return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, INFINITE_START_TIME, INFINITE_END_TIME);
+    }
+
+    public static RegisterProductRequest registerInvalidProductRequest() {
+        return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, LocalDateTime.now().minusHours(3), LocalDateTime.now().minusHours(2));
     }
 
     public static ProductsResponse productsResponse(final List<RegisterProductRequest> registerProductRequests) {

--- a/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
+++ b/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
@@ -41,8 +41,8 @@ public class ProductFixture {
         return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, startTime, endTime);
     }
 
-    public static ProductsResponse productsResponse(List<RegisterProductRequest> registerProductRequests) {
-        List<Product> products = registerProductRequests.stream().map(product -> new Product(
+    public static ProductsResponse productsResponse(final List<RegisterProductRequest> registerProductRequests) {
+        final List<Product> products = registerProductRequests.stream().map(product -> new Product(
             UNKNOWN_ID,
             product.name(),
             Long.valueOf(product.price()),

--- a/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
+++ b/app/src/test/java/shop/woowasap/accept/support/fixture/ProductFixture.java
@@ -1,7 +1,11 @@
 package shop.woowasap.accept.support.fixture;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import shop.woowasap.mock.dto.LoginRequest;
+import shop.woowasap.mock.dto.ProductsResponse;
+import shop.woowasap.mock.dto.ProductsResponse.Product;
 import shop.woowasap.shop.app.api.request.RegisterProductRequest;
 
 public class ProductFixture {
@@ -15,6 +19,10 @@ public class ProductFixture {
     public static final long QUANTITY = 10L;
     public static final LocalDateTime START_TIME = LocalDateTime.of(2023, 8, 5, 12, 30);
     public static final LocalDateTime END_TIME = LocalDateTime.of(2023, 8, 5, 14, 30);
+    public static final long UNKNOWN_ID = 1L;
+    public static final int PAGE = 1;
+    public static final int TOTAL_PAGE = 1;
+
 
     public static LoginRequest loginRequest() {
         return new LoginRequest(USER_ID, PASSWORD);
@@ -26,5 +34,22 @@ public class ProductFixture {
 
     public static RegisterProductRequest registerProductRequest() {
         return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, START_TIME, END_TIME);
+    }
+
+    public static RegisterProductRequest registerProductRequestWithTime(LocalDateTime startTime,
+        LocalDateTime endTime) {
+        return new RegisterProductRequest(NAME, DESCRIPTION, PRICE, QUANTITY, startTime, endTime);
+    }
+
+    public static ProductsResponse productsResponse(List<RegisterProductRequest> registerProductRequests) {
+        List<Product> products = registerProductRequests.stream().map(product -> new Product(
+            UNKNOWN_ID,
+            product.name(),
+            Long.valueOf(product.price()),
+            product.startTime(),
+            product.endTime()
+        )).collect(Collectors.toList());
+
+        return new ProductsResponse(products, PAGE, TOTAL_PAGE);
     }
 }

--- a/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.List;
 import shop.woowasap.mock.dto.ProductsResponse;
-import shop.woowasap.mock.dto.ProductsResponse.Product;
 
 public final class ShopValidator {
 
@@ -28,28 +26,8 @@ public final class ShopValidator {
         HttpValidator.assertOk(result);
 
         ProductsResponse resultResponse = result.as(ProductsResponse.class);
-        assertThat(resultResponse).usingRecursiveComparison().isEqualTo(expected);
+        assertThat(resultResponse).usingRecursiveComparison().ignoringFields("id")
+            .isEqualTo(expected);
     }
 
-    private static void assertProducts(ProductsResponse result, ProductsResponse expected) {
-        assertThat(result.page()).isEqualTo(expected.page());
-        assertThat(result.totalPage()).isEqualTo(expected.totalPage());
-        assertProductsExceptId(result, expected);
-    }
-
-    private static void assertProductsExceptId(ProductsResponse result, ProductsResponse expected) {
-        List<Product> resultList = result.products();
-        List<ProductsResponse.Product> expectedList = expected.products();
-        assertThat(resultList).hasSize(expectedList.size());
-
-        for (int i = 0; i < resultList.size(); i++) {
-            ProductsResponse.Product resultElement = resultList.get(i);
-            ProductsResponse.Product expectedElement = expectedList.get(i);
-
-            assertThat(resultElement.name()).isEqualTo(expectedElement.name());
-            assertThat(resultElement.price()).isEqualTo(expectedElement.price());
-            assertThat(resultElement.endTime()).isEqualTo(expectedElement.endTime());
-            assertThat(resultElement.startTime()).isEqualTo(expectedElement.startTime());
-        }
-    }
 }

--- a/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
@@ -28,13 +28,12 @@ public final class ShopValidator {
         HttpValidator.assertOk(result);
 
         ProductsResponse resultResponse = result.as(ProductsResponse.class);
-        assertProducts(resultResponse, expected);
+        assertThat(resultResponse).usingRecursiveComparison().isEqualTo(expected);
     }
 
     private static void assertProducts(ProductsResponse result, ProductsResponse expected) {
         assertThat(result.page()).isEqualTo(expected.page());
         assertThat(result.totalPage()).isEqualTo(expected.totalPage());
-
         assertProductsExceptId(result, expected);
     }
 


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 상품 전체 조회 인수테스트를 작성했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 판매가 끝나지 않은 상품 2개와 판매가 끝난 상품 1개를 등록
- [x] 상품 전체를 조회할 경우, 판매가 끝나지 않은 상품 2개만 조회 가능

## 🦀 이슈 넘버
- resolve #31 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
