### PR TITLE
test: 어드민 상품 상세 조회 인수테스트 작성

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
@@ -43,7 +43,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final UpdateProductRequest updateProductRequest = updateProductRequest();
 
         // when
-        ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
+        final ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
             productId,
             updateProductRequest);
 
@@ -62,7 +62,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final UpdateProductRequest updateProductRequest = updateProductRequest();
 
         // when
-        ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
+        final ExtractableResponse<Response> response = ShopApiSupporter.updateProduct(accessToken,
             invalidProductId,
             updateProductRequest);
 
@@ -140,10 +140,10 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
         final long anyProductId = productsResponse.products().get(0).productId();
 
-        ProductResponse expected = ProductFixture.productResponse(registerProductRequest);
+        final ProductResponse expected = ProductFixture.productResponse(registerProductRequest);
 
         // when
-        ExtractableResponse<Response> result = ShopApiSupporter.getProduct(anyProductId);
+        final ExtractableResponse<Response> result = ShopApiSupporter.getProduct(anyProductId);
 
         // then
         ShopValidator.assertProduct(result, expected);
@@ -156,7 +156,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final long notFoundProductId = 123L;
 
         // when
-        ExtractableResponse<Response> result = ShopApiSupporter.getProduct(notFoundProductId);
+        final ExtractableResponse<Response> result = ShopApiSupporter.getProduct(notFoundProductId);
 
         // then
         HttpValidator.assertBadRequest(result);
@@ -176,10 +176,10 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
         final long anyProductId = productsResponse.products().get(0).productId();
 
-        ProductResponse expected = ProductFixture.productResponse(registerProductRequest);
+        final ProductResponse expected = ProductFixture.productResponse(registerProductRequest);
 
         // when
-        ExtractableResponse<Response> result = ShopApiSupporter.getProductWithAdmin(token,
+        final ExtractableResponse<Response> result = ShopApiSupporter.getProductWithAdmin(token,
             anyProductId);
 
         // then
@@ -194,7 +194,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final long notFoundProductId = 123L;
 
         // when
-        ExtractableResponse<Response> result = ShopApiSupporter.getProductWithAdmin(token, notFoundProductId);
+        final ExtractableResponse<Response> result = ShopApiSupporter.getProductWithAdmin(token, notFoundProductId);
 
         // then
         HttpValidator.assertBadRequest(result);

--- a/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/ProductAcceptanceTest.java
@@ -97,7 +97,8 @@ class ProductAcceptanceTest extends AcceptanceTest {
         registerProduct(accessToken, validRegisterProductRequest);
         registerProduct(accessToken, validRegisterProductRequest);
 
-        final List<RegisterProductRequest> registerProductRequests = List.of(validRegisterProductRequest, validRegisterProductRequest);
+        final List<RegisterProductRequest> registerProductRequests = List.of(
+            validRegisterProductRequest, validRegisterProductRequest);
 
         // when
         final ExtractableResponse<Response> response = ShopApiSupporter.getAllProducts();
@@ -156,6 +157,44 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
         // when
         ExtractableResponse<Response> result = ShopApiSupporter.getProduct(notFoundProductId);
+
+        // then
+        HttpValidator.assertBadRequest(result);
+    }
+
+    @Test
+    @DisplayName("Admin 유저가 저장되어있는 특정 상품을 조회할경우, 상품의 정보가 응답된다.")
+    void findSpecificProductWithAdmin() {
+        // given
+        final String token = "MOCK TOKEN";
+        final RegisterProductRequest registerProductRequest = ProductFixture.registerProductRequest();
+
+        ShopApiSupporter.registerProduct(token, registerProductRequest);
+
+        final ProductsResponse productsResponse = ShopApiSupporter.getRegisteredProducts(token)
+            .as(ProductsResponse.class);
+
+        final long anyProductId = productsResponse.products().get(0).productId();
+
+        ProductResponse expected = ProductFixture.productResponse(registerProductRequest);
+
+        // when
+        ExtractableResponse<Response> result = ShopApiSupporter.getProductWithAdmin(token,
+            anyProductId);
+
+        // then
+        ShopValidator.assertProduct(result, expected);
+    }
+
+    @Test
+    @DisplayName("Admin 유저가 productId에 해당하는 상품을 찾을 수 없다면, 400 BadRequest가 응답된다.")
+    void returnBadRequestWhenCannotFoundProductWithAdmin() {
+        // given
+        final String token = "MOCK TOKEN";
+        final long notFoundProductId = 123L;
+
+        // when
+        ExtractableResponse<Response> result = ShopApiSupporter.getProductWithAdmin(token, notFoundProductId);
 
         // then
         HttpValidator.assertBadRequest(result);

--- a/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
@@ -72,4 +72,15 @@ public final class ShopApiSupporter {
             .then().log().all()
             .extract();
     }
+
+    public static ExtractableResponse<Response> getProductWithAdmin(final String token,
+        final long productId) {
+        return given().log().all()
+            .accept(JSON)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .when().log().all()
+            .get(API_VERSION + "/admin/products/{product-id}", productId)
+            .then().log().all()
+            .extract();
+    }
 }

--- a/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/ShopApiSupporter.java
@@ -16,8 +16,8 @@ public final class ShopApiSupporter {
     private ShopApiSupporter() {
     }
 
-    public static ExtractableResponse<Response> registerProduct(String token,
-        RegisterProductRequest registerProductRequest) {
+    public static ExtractableResponse<Response> registerProduct(final String token,
+        final RegisterProductRequest registerProductRequest) {
 
         return given().log().all()
             .contentType(JSON)
@@ -30,9 +30,9 @@ public final class ShopApiSupporter {
             .extract();
     }
 
-    public static ExtractableResponse<Response> updateProduct(String token,
-        long productId,
-        UpdateProductRequest updateProductRequest) {
+    public static ExtractableResponse<Response> updateProduct(final String token,
+        final long productId,
+        final UpdateProductRequest updateProductRequest) {
 
         return given().log().all()
             .contentType(JSON)
@@ -54,7 +54,7 @@ public final class ShopApiSupporter {
             .extract();
     }
 
-    public static ExtractableResponse<Response> getRegisteredProducts(String token) {
+    public static ExtractableResponse<Response> getRegisteredProducts(final String token) {
         return given().log().all()
             .accept(JSON)
             .header(HttpHeaders.AUTHORIZATION, token)
@@ -64,7 +64,7 @@ public final class ShopApiSupporter {
             .extract();
     }
 
-    public static ExtractableResponse<Response> getProduct(long productId) {
+    public static ExtractableResponse<Response> getProduct(final long productId) {
         return given().log().all()
             .accept(JSON)
             .when().log().all()


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

상품 상세 조회 어드민인 경우 인수테스트를 작성했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] `ProductAcceptanceTest` 에 어드민인 경우 상품 상세 조회 테스트 추가
- [x] `ShopApiSupport`에 어드민 상품 상세 조회 테스트 API 추가

## 🦀 이슈 넘버

- resolve #55 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
