### PR TITLE
feat: 어드민 상품 상세 조회 컨트롤러 구현

### DIFF
--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.shop.app.api.ProductUseCase;
 import shop.woowasap.shop.app.api.request.RegisterProductRequest;
 import shop.woowasap.shop.app.api.request.UpdateProductRequest;
+import shop.woowasap.shop.app.api.response.ProductResponse;
 import shop.woowasap.shop.app.api.response.ProductsResponse;
 import shop.woowasap.shop.app.exception.CannotFindProductException;
 
@@ -49,6 +50,13 @@ public class ProductAdminController {
         final ProductsResponse productsResponse = productUseCase.getProductsInAdmin(page, size);
 
         return ResponseEntity.ok(productsResponse);
+    }
+
+    @GetMapping("/{product-id}")
+    public ResponseEntity<ProductResponse> readProductInAdmin(@PathVariable("product-id") final Long productId) {
+        final ProductResponse productResponse = productUseCase.getByIdWithAdmin(productId);
+
+        return ResponseEntity.ok(productResponse);
     }
 
     @ExceptionHandler(CannotFindProductException.class)

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
@@ -43,7 +43,7 @@ public class ProductAdminController {
     }
 
     @GetMapping
-    public ResponseEntity<ProductsResponse> readProductsInAdmin(
+    public ResponseEntity<ProductsResponse> readProducts(
         @RequestParam(defaultValue = "1") final int page,
         @RequestParam(defaultValue = "20") final int size
     ) {
@@ -53,7 +53,8 @@ public class ProductAdminController {
     }
 
     @GetMapping("/{product-id}")
-    public ResponseEntity<ProductResponse> readProductInAdmin(@PathVariable("product-id") final Long productId) {
+    public ResponseEntity<ProductResponse> readProduct(
+        @PathVariable("product-id") final Long productId) {
         final ProductResponse productResponse = productUseCase.getByIdWithAdmin(productId);
 
         return ResponseEntity.ok(productResponse);


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

어드민 상품 상세 조회 컨트롤러를 구현했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] `ProductAdminController` 에 `/v1/admin/products/{product-id}` API 추가

## 🦀 이슈 넘버

- resolve #55 

## (option) 어떤 부분에 집중하여 리뷰해야 할까요?

- `ProductAdminController` 에서 `readProductsInAdmin`, `readProductInAdmin` 메서드에서 Admin 인 경우임을 메서드 명에서 명시하고 있는데, 이제는 `ProductAdminController`로 Admin 전용 컨트롤러임을 명시하므로 `InAdmin` 를 없애도 괜찮지 않을까요?
  - 일단은 붙여 놨는데, 혹시 다른 분들은 어떤 생각이실지 궁금해요!

<!--
## 참고자료
-->
