### PR TITLE
test: 상품 구매 인수테스트 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -1,0 +1,68 @@
+package shop.woowasap.accept;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.woowasap.accept.support.api.OrderApiSupporter;
+import shop.woowasap.accept.support.valid.HttpValidator;
+import shop.woowasap.accept.support.valid.OrderValidator;
+import shop.woowasap.mock.dto.OrderProductRequest;
+
+@DisplayName("Order 인수테스트")
+class OrderAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("상품 바로 구매 API는 productId와 quantity를 받아 상품을 구매한후, Created와 Location을 응답한다.")
+    void returnCreatedAndLocationWhenSuccessToBuyProduct() {
+        // given
+        final String token = "TOKEN";
+
+        final long productId = 1L;
+        final int quantity = 2;
+        final OrderProductRequest orderProductRequest = new OrderProductRequest(quantity);
+
+        // when
+        final ExtractableResponse<Response> result = OrderApiSupporter.orderProduct(productId, orderProductRequest,
+                token);
+
+        // then
+        OrderValidator.assertOrdered(result);
+    }
+
+    @Test
+    @DisplayName("상품 바로 구매 API는 productId에 해당하는 product를 찾을 수 없는경우, 400 BadRequest를 응답한다.")
+    void returnBadRequestWhenCannotFindMatchedProduct() {
+        // given
+        final String token = "TOKEN";
+
+        final long notExistProductId = 123L;
+        final int quantity = 2;
+        final OrderProductRequest orderProductRequest = new OrderProductRequest(quantity);
+
+        // when
+        final ExtractableResponse<Response> result = OrderApiSupporter.orderProduct(notExistProductId,
+                orderProductRequest, token);
+
+        // then
+        HttpValidator.assertBadRequest(result);
+    }
+
+    @Test
+    @DisplayName("상품 바로 구매 API는 product를 구매할 돈이 없으면, 400 BadRequest를 응답한다.")
+    void returnBadRequestWhenDoesNotHaveEnoughMoneyToBuyProduct() {
+        // given
+        final String token = "TOKEN";
+
+        final long notExistProductId = 1L;
+        final int quantity = 2;
+        final OrderProductRequest orderProductRequest = new OrderProductRequest(quantity);
+
+        // when
+        final ExtractableResponse<Response> result = OrderApiSupporter.orderProduct(notExistProductId,
+                orderProductRequest, token);
+
+        // then
+        HttpValidator.assertBadRequest(result);
+    }
+}

--- a/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
@@ -10,7 +10,7 @@ import shop.woowasap.mock.dto.OrderProductRequest;
 
 public final class OrderApiSupporter {
 
-    private static final String API_VERSION = "V1";
+    private static final String API_VERSION = "v1";
 
     private OrderApiSupporter() {
         throw new UnsupportedOperationException("Cannot invoke constructor \"OrderApiSupporter()\"");

--- a/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
@@ -1,0 +1,33 @@
+package shop.woowasap.accept.support.api;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpHeaders;
+import shop.woowasap.mock.dto.OrderProductRequest;
+
+public final class OrderApiSupporter {
+
+    private static final String API_VERSION = "V1";
+
+    private OrderApiSupporter() {
+        throw new UnsupportedOperationException("Cannot invoke constructor \"OrderApiSupporter()\"");
+    }
+
+    public static ExtractableResponse<Response> orderProduct(final long productId,
+            final OrderProductRequest orderProductRequest, final String token) {
+
+        return given().log().all()
+                .contentType(JSON)
+                .accept(JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .body(orderProductRequest)
+                .when().log().all()
+                .post(API_VERSION + "/orders/products/{product-id}", productId)
+                .then().log().all()
+                .extract();
+    }
+
+}

--- a/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
@@ -1,0 +1,20 @@
+package shop.woowasap.accept.support.valid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpHeaders;
+
+public final class OrderValidator {
+
+    private OrderValidator() {
+        throw new UnsupportedOperationException("Cannot invoke constructor \"OrderValidator()\"");
+    }
+
+    public static void assertOrdered(ExtractableResponse<Response> result) {
+        HttpValidator.assertCreated(result);
+
+        assertThat(result.header(HttpHeaders.AUTHORIZATION)).contains("/v1/orders/");
+    }
+}

--- a/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
@@ -15,6 +15,6 @@ public final class OrderValidator {
     public static void assertOrdered(ExtractableResponse<Response> result) {
         HttpValidator.assertCreated(result);
 
-        assertThat(result.header(HttpHeaders.AUTHORIZATION)).contains("/v1/orders/");
+        assertThat(result.header(HttpHeaders.LOCATION)).contains("/v1/orders/");
     }
 }

--- a/app/src/test/java/shop/woowasap/mock/dto/OrderProductRequest.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/OrderProductRequest.java
@@ -1,0 +1,4 @@
+package shop.woowasap.mock.dto;
+
+public record OrderProductRequest(int quantity) {
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'ASAP'
+rootProject.name = 'asap'
 
 include 'app'
 


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
상품 구매 인수테스트를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 상품 구매를 성공할경우, `Created`와 `Location`을 응답하는걸 테스트 했습니다.
- [x] 구매할 상품의 id를 찾을 수 없는경우, `400 Bad Request` 응답을 테스트 했습니다.
- [x] 상품을 구매하기에 돈이 충분하지 않은경우, `400 Bad Request` 응답을 테스트 했습니다.

## 🦀 이슈 넘버
- resolve #57 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
