### PR TITLE
feat: 상품 단일 구매 서비스 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,gradle,intellij+all,visualstudiocode
+!*/**/out/

--- a/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
@@ -8,6 +8,7 @@ import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
 import shop.woowasap.mock.dto.OrderProductRequest;
 
+
 public final class OrderApiSupporter {
 
     private static final String API_VERSION = "v1";

--- a/app/src/test/java/shop/woowasap/mock/dto/OrderProductRequest.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/OrderProductRequest.java
@@ -1,4 +1,4 @@
 package shop.woowasap.mock.dto;
 
-public record OrderProductRequest(int quantity) {
+public record OrderProductRequest(long quantity) {
 }

--- a/coverage-exclude.asap
+++ b/coverage-exclude.asap
@@ -7,3 +7,5 @@ exclude shop/woowasap/*/app/api/response/*
 exclude shop/woowasap/*/app/spi/request/*
 exclude shop/woowasap/*/app/spi/response/*
 exclude shop/woowasap/*/app/exception/*
+exclude shop/woowasap/order/domain/exception/*
+exclude shop/woowasap/order/domain/in/request/*

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/Order.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/Order.java
@@ -11,13 +11,15 @@ import shop.woowasap.order.domain.exception.InvalidOrderProductException;
 public class Order {
 
     private final long id;
+    private final long userId;
     private final List<OrderProduct> orderProducts;
     private final BigInteger totalPrice;
 
     @Builder
-    private Order(final long id, final List<OrderProduct> orderProducts) {
+    private Order(final long id, final long userId, final List<OrderProduct> orderProducts) {
         validOrderProducts(orderProducts);
         this.id = id;
+        this.userId = userId;
         this.orderProducts = orderProducts;
         this.totalPrice = calculatePrice();
     }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/OrderProduct.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/OrderProduct.java
@@ -13,11 +13,11 @@ import shop.woowasap.order.domain.exception.InvalidQuantityException;
 public class OrderProduct {
 
     private final long productId;
-    private final int quantity;
+    private final long quantity;
     private final BigInteger price;
 
     @Builder
-    private OrderProduct(final long productId, final int quantity, final String price,
+    private OrderProduct(final long productId, final long quantity, final String price,
             final Instant startTime, final Instant endTime) {
         validPrice(price);
         validQuantity(quantity);
@@ -46,7 +46,7 @@ public class OrderProduct {
         }
     }
 
-    private void validQuantity(final int quantity) {
+    private void validQuantity(final long quantity) {
         if (quantity <= 0) {
             throw new InvalidQuantityException(quantity);
         }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/OrderProduct.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/OrderProduct.java
@@ -1,10 +1,12 @@
 package shop.woowasap.order.domain;
 
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import shop.woowasap.order.domain.exception.InvalidPriceException;
+import shop.woowasap.order.domain.exception.InvalidProductSaleTimeException;
 import shop.woowasap.order.domain.exception.InvalidQuantityException;
 
 @Getter
@@ -15,9 +17,11 @@ public class OrderProduct {
     private final BigInteger price;
 
     @Builder
-    private OrderProduct(final long productId, final int quantity, final String price) {
+    private OrderProduct(final long productId, final int quantity, final String price,
+            final Instant startTime, final Instant endTime) {
         validPrice(price);
         validQuantity(quantity);
+        validateProductSaleTime(startTime, endTime);
         this.productId = productId;
         this.quantity = quantity;
         this.price = new BigInteger(price).multiply(BigInteger.valueOf(quantity));
@@ -45,6 +49,13 @@ public class OrderProduct {
     private void validQuantity(final int quantity) {
         if (quantity <= 0) {
             throw new InvalidQuantityException(quantity);
+        }
+    }
+
+    private void validateProductSaleTime(final Instant startTime, final Instant endTime) {
+        final Instant currentTime = Instant.now();
+        if (currentTime.isBefore(startTime) || currentTime.isAfter(endTime)) {
+            throw new InvalidProductSaleTimeException(startTime, currentTime, endTime);
         }
     }
 }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/DoesNotOrderedException.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/DoesNotOrderedException.java
@@ -1,0 +1,8 @@
+package shop.woowasap.order.domain.exception;
+
+public class DoesNotOrderedException extends RuntimeException {
+
+    public DoesNotOrderedException() {
+        super("결제에 실패했습니다.");
+    }
+}

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/InvalidProductSaleTimeException.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/InvalidProductSaleTimeException.java
@@ -1,0 +1,13 @@
+package shop.woowasap.order.domain.exception;
+
+import java.text.MessageFormat;
+import java.time.Instant;
+
+public class InvalidProductSaleTimeException extends RuntimeException {
+
+    public InvalidProductSaleTimeException(Instant startTime, Instant currentTime, Instant endTime) {
+        super(MessageFormat.format(
+                "상품을 구매할 수 있는시간은 startTime \"{0}\" <= currentTime \"{1}\" < endTime \"{2}\" 를 만족해야 합니다.", startTime,
+                currentTime, endTime));
+    }
+}

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/InvalidQuantityException.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/InvalidQuantityException.java
@@ -4,7 +4,7 @@ import java.text.MessageFormat;
 
 public class InvalidQuantityException extends RuntimeException {
 
-    public InvalidQuantityException(int quantity) {
+    public InvalidQuantityException(long quantity) {
         super(MessageFormat.format("quantity \"{0}\" 는 0 이하가 될 수 없습니다.", quantity));
     }
 }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
@@ -1,0 +1,9 @@
+package shop.woowasap.order.domain.in;
+
+import shop.woowasap.order.domain.in.request.OrderProductRequest;
+
+public interface OrderUseCase {
+
+    long orderProduct(final OrderProductRequest orderProductRequest);
+
+}

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/request/OrderProductRequest.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/request/OrderProductRequest.java
@@ -1,0 +1,4 @@
+package shop.woowasap.order.domain.in.request;
+
+public record OrderProductRequest(long userId, long productId, long quantity) {
+}

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/out/OrderRepository.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/out/OrderRepository.java
@@ -1,0 +1,8 @@
+package shop.woowasap.order.domain.out;
+
+import shop.woowasap.order.domain.Order;
+
+public interface OrderRepository {
+
+    void persist(Order order);
+}

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/out/Payment.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/out/Payment.java
@@ -1,0 +1,7 @@
+package shop.woowasap.order.domain.out;
+
+public interface Payment {
+
+    boolean pay(long userId);
+
+}

--- a/order/order-domain/src/test/java/shop/woowasap/order/domain/OrderProductTest.java
+++ b/order/order-domain/src/test/java/shop/woowasap/order/domain/OrderProductTest.java
@@ -3,10 +3,12 @@ package shop.woowasap.order.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
+import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import shop.woowasap.order.domain.exception.InvalidPriceException;
+import shop.woowasap.order.domain.exception.InvalidProductSaleTimeException;
 import shop.woowasap.order.domain.exception.InvalidQuantityException;
 import shop.woowasap.order.domain.support.fixture.OrderProductFixture;
 
@@ -24,12 +26,16 @@ class OrderProductTest {
             final long productId = 1L;
             final int quantity = 2;
             final String price = "10000";
+            final Instant startTime = Instant.now().minusSeconds(100);
+            final Instant endTime = Instant.now().plusSeconds(100);
 
             // when
             final Exception exception = catchException(() -> OrderProduct.builder()
                     .productId(productId)
                     .quantity(quantity)
                     .price(price)
+                    .startTime(startTime)
+                    .endTime(endTime)
                     .build());
 
             // then
@@ -82,6 +88,36 @@ class OrderProductTest {
 
             // then
             assertThat(exception).isInstanceOf(InvalidQuantityException.class);
+        }
+
+        @Test
+        @DisplayName("startTime > currentTime 이라면, InvalidProductSaleTimeException을 던진다.")
+        void throwInvalidProductSaleTimeExceptionWhenStartTimeIsAfterCurrentTime() {
+            // given
+            final Instant invalidStartTime = Instant.now().plusSeconds(100);
+            final OrderProduct.OrderProductBuilder orderProductBuilder = OrderProductFixture.defaultBuilder();
+
+            // when
+            final Exception exception = catchException(() -> orderProductBuilder.startTime(invalidStartTime)
+                    .build());
+
+            // then
+            assertThat(exception).isInstanceOf(InvalidProductSaleTimeException.class);
+        }
+
+        @Test
+        @DisplayName("endTime < currentTime 이라면, InvalidProductSaleTimeException을 던진다.")
+        void throwInvalidProductSaleTimeExceptionWhenEndTimeIsBeforeCurrentTime() {
+            // given
+            final Instant invalidEndTime = Instant.now().minusSeconds(100);
+            final OrderProduct.OrderProductBuilder orderProductBuilder = OrderProductFixture.defaultBuilder();
+
+            // when
+            final Exception exception = catchException(() -> orderProductBuilder.endTime(invalidEndTime)
+                    .build());
+
+            // then
+            assertThat(exception).isInstanceOf(InvalidProductSaleTimeException.class);
         }
     }
 }

--- a/order/order-domain/src/test/java/shop/woowasap/order/domain/OrderProductTest.java
+++ b/order/order-domain/src/test/java/shop/woowasap/order/domain/OrderProductTest.java
@@ -24,7 +24,7 @@ class OrderProductTest {
         void createSuccessWhenReceiveProductInfoAndQuantity() {
             // given
             final long productId = 1L;
-            final int quantity = 2;
+            final long quantity = 2L;
             final String price = "10000";
             final Instant startTime = Instant.now().minusSeconds(100);
             final Instant endTime = Instant.now().plusSeconds(100);
@@ -78,7 +78,7 @@ class OrderProductTest {
         @DisplayName("quantity가 0 이하라면, InvalidQuantityException을 던진다.")
         void throwInvalidQuantityExceptionWhenQuantityUnderZero() {
             // given
-            final int zeroQuantity = 0;
+            final long zeroQuantity = 0L;
             final OrderProduct.OrderProductBuilder defaultOrderProductBuilder = OrderProductFixture.defaultBuilder();
 
             // when

--- a/order/order-domain/src/test/java/shop/woowasap/order/domain/support/fixture/OrderFixture.java
+++ b/order/order-domain/src/test/java/shop/woowasap/order/domain/support/fixture/OrderFixture.java
@@ -7,6 +7,7 @@ import shop.woowasap.order.domain.OrderProduct;
 public class OrderFixture {
 
     private static final long DEFAULT_ORDER_ID = 1L;
+    private static final long DEFAULT_USER_ID = 1L;
 
     private static final List<OrderProduct> DEFAULT_ORDER_PRODUCTS = List.of(
             OrderProductFixture.defaultProduct(),
@@ -21,6 +22,7 @@ public class OrderFixture {
     public static Order.OrderBuilder defaultBuilder() {
         return Order.builder()
                 .id(DEFAULT_ORDER_ID)
+                .userId(DEFAULT_USER_ID)
                 .orderProducts(DEFAULT_ORDER_PRODUCTS);
     }
 

--- a/order/order-domain/src/test/java/shop/woowasap/order/domain/support/fixture/OrderProductFixture.java
+++ b/order/order-domain/src/test/java/shop/woowasap/order/domain/support/fixture/OrderProductFixture.java
@@ -18,13 +18,14 @@ public final class OrderProductFixture {
     }
 
     public static OrderProduct.OrderProductBuilder defaultBuilder() {
-        Instant currentTime = Instant.now();
+        Instant startTime = Instant.now().minusSeconds(100);
+        Instant endTime = Instant.now().plusSeconds(100);
         return OrderProduct.builder()
                 .productId(DEFAULT_PRODUCT_ID)
                 .quantity(DEFAULT_QUANTITY)
                 .price(DEFAULT_PRICE)
-                .startTime(currentTime)
-                .endTime(currentTime);
+                .startTime(startTime)
+                .endTime(endTime);
     }
 
 }

--- a/order/order-domain/src/test/java/shop/woowasap/order/domain/support/fixture/OrderProductFixture.java
+++ b/order/order-domain/src/test/java/shop/woowasap/order/domain/support/fixture/OrderProductFixture.java
@@ -1,11 +1,12 @@
 package shop.woowasap.order.domain.support.fixture;
 
+import java.time.Instant;
 import shop.woowasap.order.domain.OrderProduct;
 
 public final class OrderProductFixture {
 
     private static final long DEFAULT_PRODUCT_ID = 1L;
-    private static final int DEFAULT_QUANTITY = 1;
+    private static final long DEFAULT_QUANTITY = 1L;
     private static final String DEFAULT_PRICE = "1";
 
     private OrderProductFixture() {
@@ -17,10 +18,13 @@ public final class OrderProductFixture {
     }
 
     public static OrderProduct.OrderProductBuilder defaultBuilder() {
+        Instant currentTime = Instant.now();
         return OrderProduct.builder()
                 .productId(DEFAULT_PRODUCT_ID)
                 .quantity(DEFAULT_QUANTITY)
-                .price(DEFAULT_PRICE);
+                .price(DEFAULT_PRICE)
+                .startTime(currentTime)
+                .endTime(currentTime);
     }
 
 }

--- a/order/order-service/build.gradle
+++ b/order/order-service/build.gradle
@@ -1,3 +1,7 @@
 dependencies {
+    implementation project(':core:id-gen')
+    implementation project(':shop:shop-domain')
     implementation project(':order:order-domain')
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -1,0 +1,40 @@
+package shop.woowasap.order.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.woowasap.core.id.api.IdGenerator;
+import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.exception.DoesNotOrderedException;
+import shop.woowasap.order.domain.in.OrderUseCase;
+import shop.woowasap.order.domain.in.request.OrderProductRequest;
+import shop.woowasap.order.domain.out.OrderRepository;
+import shop.woowasap.order.domain.out.Payment;
+import shop.woowasap.order.service.mapper.OrderMapper;
+import shop.woowasap.shop.app.api.ProductConnector;
+import shop.woowasap.shop.app.product.Product;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService implements OrderUseCase {
+
+    private final Payment payment;
+    private final IdGenerator idGenerator;
+    private final ProductConnector productConnector;
+    private final OrderRepository orderRepository;
+
+    @Override
+    @Transactional
+    public long orderProduct(final OrderProductRequest orderProductRequest) {
+        final Product product = productConnector.getById(orderProductRequest.productId());
+        final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest.userId(), product);
+
+        if (!payment.pay(orderProductRequest.userId())) {
+            throw new DoesNotOrderedException();
+        }
+
+        orderRepository.persist(order);
+        return order.getId();
+    }
+}

--- a/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
@@ -1,0 +1,30 @@
+package shop.woowasap.order.service.mapper;
+
+import java.util.List;
+import shop.woowasap.core.id.api.IdGenerator;
+import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.OrderProduct;
+import shop.woowasap.shop.app.product.Product;
+
+public final class OrderMapper {
+
+    private OrderMapper() {
+        throw new UnsupportedOperationException("Cannot invoke constructor \"OrderMapper()\"");
+    }
+
+    public static Order toDomain(final IdGenerator idGenerator, final long userId, final Product product) {
+        return Order.builder()
+                .id(idGenerator.generate())
+                .userId(userId)
+                .orderProducts(List.of(OrderProduct
+                        .builder()
+                        .productId(product.getId())
+                        .price(product.getPrice().getValue().toString())
+                        .quantity(product.getQuantity().getValue())
+                        .startTime(product.getStartTime())
+                        .endTime(product.getEndTime())
+                        .build()))
+                .build();
+    }
+
+}

--- a/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
@@ -1,0 +1,92 @@
+package shop.woowasap.order.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import shop.woowasap.core.id.api.IdGenerator;
+import shop.woowasap.order.domain.exception.DoesNotOrderedException;
+import shop.woowasap.order.domain.in.OrderUseCase;
+import shop.woowasap.order.domain.in.request.OrderProductRequest;
+import shop.woowasap.order.domain.out.OrderRepository;
+import shop.woowasap.order.domain.out.Payment;
+import shop.woowasap.order.service.support.fixture.ProductFixture;
+import shop.woowasap.shop.app.api.ProductConnector;
+
+@DisplayName("OrderService 클래스")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = OrderService.class)
+class OrderServiceTest {
+
+    @Autowired
+    private OrderUseCase orderUseCase;
+
+    @MockBean
+    private IdGenerator idGenerator;
+
+    @MockBean
+    private ProductConnector productConnector;
+
+    @MockBean
+    private OrderRepository orderRepository;
+
+    @MockBean
+    private Payment payment;
+
+    @Nested
+    @DisplayName("order 메소드는")
+    class orderMethod {
+
+        @Test
+        @DisplayName("userId, productId, OrderProductRequest 를 받아 주문을 한다.")
+        void successOrderWhenReceiveUserIdAndOrderProductRequest() {
+            // given
+            final long userId = 1L;
+            final long productId = 2L;
+            final int quantity = 3;
+            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId, productId, quantity);
+
+            final long orderId = 1L;
+            when(idGenerator.generate()).thenReturn(orderId);
+            when(productConnector.getById(productId)).thenReturn(ProductFixture.getDefaultBuilder()
+                    .build());
+            when(payment.pay(userId)).thenReturn(true);
+
+            // when
+            final long result = orderUseCase.orderProduct(orderProductRequest);
+
+            // then
+            assertThat(result).isEqualTo(orderId);
+        }
+
+        @Test
+        @DisplayName("주문을 실패하면, DoesNotOrderedException을 던진다.")
+        void throwDoesNotOrderedExceptionWhenFailToOrder() {
+            // given
+            final long userId = 1L;
+            final long productId = 2L;
+            final int quantity = 3;
+            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId, productId, quantity);
+
+            final long orderId = 1L;
+            when(idGenerator.generate()).thenReturn(orderId);
+            when(productConnector.getById(productId)).thenReturn(ProductFixture.getDefaultBuilder()
+                    .build());
+            when(payment.pay(userId)).thenReturn(false);
+
+            // when
+            final Exception exception = catchException(() -> orderUseCase.orderProduct(orderProductRequest));
+
+            // then
+            assertThat(exception).isInstanceOf(DoesNotOrderedException.class);
+        }
+    }
+}

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/ProductFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/ProductFixture.java
@@ -1,0 +1,24 @@
+package shop.woowasap.order.service.support.fixture;
+
+import java.time.Instant;
+import shop.woowasap.shop.app.product.Product;
+
+public class ProductFixture {
+
+    private ProductFixture() {
+        throw new UnsupportedOperationException("Cannot invoke constructor \"DomainFixture()\"");
+    }
+
+    public static Product.ProductBuilder getDefaultBuilder() {
+        final Instant startTime = Instant.now().minusSeconds(100);
+        final Instant endTime = Instant.now().plusSeconds(100);
+        return Product.builder()
+                .id(1L)
+                .name("name")
+                .description("description")
+                .price("10000")
+                .quantity(1000L)
+                .startTime(startTime)
+                .endTime(endTime);
+    }
+}

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/app/api/ProductConnector.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/app/api/ProductConnector.java
@@ -1,0 +1,9 @@
+package shop.woowasap.shop.app.api;
+
+import shop.woowasap.shop.app.product.Product;
+
+public interface ProductConnector {
+
+    Product getById(final long id);
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
상품 단일 구매 서비스를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] OrderProduct가 생성될때 현재시간과 상품 판매가능 시간을 비교하는 로직 추가
- [x] 결제가 실패했을때, 예외를 던지는 로직 추가
- [x] shop domain에 domain간 연결하는 `ProductConnector` 인터페이스 추가
- [x] Order domain에서 userId를 갖도록 추가

## 🦀 이슈 넘버
- resolve #57 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
