### PR TITLE
feat: 0~1초 뒤 성공을 반환하는 RandomOrderPayment 생성

### DIFF
--- a/coverage-exclude.asap
+++ b/coverage-exclude.asap
@@ -10,3 +10,4 @@ exclude shop/woowasap/*/app/exception/*
 exclude shop/woowasap/order/domain/exception/*
 exclude shop/woowasap/order/domain/in/request/*
 exclude shop/woowasap/order/repository/*
+exclude shop/woowasap/order/payment/random/RandomOrderPayment

--- a/order/order-infra/build.gradle
+++ b/order/order-infra/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':order:order-domain')
+}

--- a/order/order-infra/src/main/java/shop/woowasap/order/payment/random/RandomOrderPayment.java
+++ b/order/order-infra/src/main/java/shop/woowasap/order/payment/random/RandomOrderPayment.java
@@ -1,0 +1,22 @@
+package shop.woowasap.order.payment.random;
+
+import java.util.Random;
+import org.springframework.stereotype.Service;
+import shop.woowasap.order.domain.out.Payment;
+
+@Service
+public class RandomOrderPayment implements Payment {
+
+    private static final int MAX_SLEEP_BOUND = 1001;
+    private static final Random random = new Random();
+
+    @Override
+    public boolean pay(long userId) {
+        try {
+            Thread.sleep(random.nextInt(MAX_SLEEP_BOUND));
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+        }
+        return true;
+    }
+}

--- a/order/order-infra/src/main/java/shop/woowasap/order/payment/random/RandomOrderPayment.java
+++ b/order/order-infra/src/main/java/shop/woowasap/order/payment/random/RandomOrderPayment.java
@@ -11,7 +11,7 @@ public class RandomOrderPayment implements Payment {
     private static final Random random = new Random();
 
     @Override
-    public boolean pay(long userId) {
+    public boolean pay(final long userId) {
         try {
             Thread.sleep(random.nextInt(MAX_SLEEP_BOUND));
         } catch (InterruptedException interruptedException) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'asap'
+rootProject.name = 'ASAP'
 
 include 'app'
 
@@ -30,7 +30,9 @@ include 'core'
 include 'core:id-gen'
 
 include 'order'
+include 'order:order-infra'
 include 'order:order-domain'
 include 'order:order-service'
 include 'order:order-controller'
 include 'order:order-repository'
+


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
0~1초뒤 true를 반환하는 RandomOrderPayment 생성

## 🕶️ 어떻게 해결했나요?
- [x] 가짜 결제 객체 `RandomOrderPayment`를 생성
- [x] `RandomOrderPayment` 가 0~1초 뒤 true를 반환하도록 생성

## 🦀 이슈 넘버
- resolve #57

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
