### PR TITLE
fix: ProductConnector 시그니처 변경 및, 예외 케이스, 예외 핸들러 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':auth:auth-controller')
     implementation project(':auth:auth-repository')
 
+    implementation project(':order:order-infra')
     implementation project(':order:order-domain')
     implementation project(':order:order-service')
     implementation project(':order:order-controller')

--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -47,22 +47,4 @@ class OrderAcceptanceTest extends AcceptanceTest {
         // then
         HttpValidator.assertBadRequest(result);
     }
-
-    @Test
-    @DisplayName("상품 바로 구매 API는 product를 구매할 돈이 없으면, 400 BadRequest를 응답한다.")
-    void returnBadRequestWhenDoesNotHaveEnoughMoneyToBuyProduct() {
-        // given
-        final String token = "TOKEN";
-
-        final long notExistProductId = 1L;
-        final int quantity = 2;
-        final OrderProductQuantityRequest orderProductRequest = new OrderProductQuantityRequest(quantity);
-
-        // when
-        final ExtractableResponse<Response> result = OrderApiSupporter.orderProduct(notExistProductId,
-                orderProductRequest, token);
-
-        // then
-        HttpValidator.assertBadRequest(result);
-    }
 }

--- a/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/ShopValidator.java
@@ -11,7 +11,7 @@ import shop.woowasap.shop.app.api.response.ProductsResponse;
 public final class ShopValidator {
 
     private static final RecursiveComparisonConfiguration IGNORE_ID_COMPARISON = RecursiveComparisonConfiguration.builder()
-        .withIgnoredFields("id")
+        .withIgnoredFields("id", "startTime", "endTime")
         .build();
 
     private ShopValidator() {
@@ -40,7 +40,7 @@ public final class ShopValidator {
         assertThat(result.totalPage()).isEqualTo(expected.totalPage());
 
         assertThat(result).usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
-            .withIgnoredFields("products.productId")
+            .withIgnoredFields("products.productId", "products.startTime", "products.endTime")
             .build()).isEqualTo(expected);
     }
 

--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -25,7 +25,8 @@ public class OrderController {
     public ResponseEntity<Void> orderProduct(@PathVariable("product-id") final long productId,
         @RequestBody final OrderProductQuantityRequest orderProductQuantityRequest) {
 
-        final OrderProductRequest orderProductRequest = new OrderProductRequest(MOCK_USER_ID, productId,
+        final OrderProductRequest orderProductRequest = new OrderProductRequest(MOCK_USER_ID,
+            productId,
             orderProductQuantityRequest.quantity());
         final long orderId = orderUseCase.orderProduct(orderProductRequest);
 

--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -3,12 +3,19 @@ package shop.woowasap.order.controller;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
+import shop.woowasap.order.domain.exception.DoesNotFindProductException;
+import shop.woowasap.order.domain.exception.DoesNotOrderedException;
+import shop.woowasap.order.domain.exception.InvalidOrderProductException;
+import shop.woowasap.order.domain.exception.InvalidPriceException;
+import shop.woowasap.order.domain.exception.InvalidProductSaleTimeException;
+import shop.woowasap.order.domain.exception.InvalidQuantityException;
 import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
 
@@ -34,4 +41,13 @@ public class OrderController {
             .build();
     }
 
+    @ExceptionHandler({DoesNotFindProductException.class,
+        DoesNotOrderedException.class,
+        InvalidOrderProductException.class,
+        InvalidPriceException.class,
+        InvalidProductSaleTimeException.class,
+        InvalidQuantityException.class})
+    private ResponseEntity<Void> handleBadRequest() {
+        return ResponseEntity.badRequest().build();
+    }
 }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/DoesNotFindProductException.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/DoesNotFindProductException.java
@@ -1,0 +1,10 @@
+package shop.woowasap.order.domain.exception;
+
+import java.text.MessageFormat;
+
+public final class DoesNotFindProductException extends RuntimeException{
+
+    public DoesNotFindProductException(long productId) {
+        super(MessageFormat.format("productId \"{0}\" 에 해당하는 Product를 찾을 수 없습니다.", productId));
+    }
+}

--- a/order/order-repository/src/main/java/shop/woowasap/order/repository/MockOrderRepository.java
+++ b/order/order-repository/src/main/java/shop/woowasap/order/repository/MockOrderRepository.java
@@ -1,8 +1,10 @@
 package shop.woowasap.order.repository;
 
+import org.springframework.stereotype.Repository;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.out.OrderRepository;
 
+@Repository
 public class MockOrderRepository implements OrderRepository {
 
     @Override

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.exception.DoesNotFindProductException;
 import shop.woowasap.order.domain.exception.DoesNotOrderedException;
 import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
@@ -27,7 +28,8 @@ public class OrderService implements OrderUseCase {
     @Override
     @Transactional
     public long orderProduct(final OrderProductRequest orderProductRequest) {
-        final Product product = productConnector.getByProductId(orderProductRequest.productId());
+        final Product product = productConnector.findByProductId(orderProductRequest.productId())
+            .orElseThrow(() -> new DoesNotFindProductException(orderProductRequest.productId()));
         final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest.userId(), product);
 
         if (!payment.pay(orderProductRequest.userId())) {

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/app/api/ProductConnector.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/app/api/ProductConnector.java
@@ -1,9 +1,10 @@
 package shop.woowasap.shop.app.api;
 
+import java.util.Optional;
 import shop.woowasap.shop.app.product.Product;
 
 public interface ProductConnector {
 
-    Product getByProductId(final long productId);
+    Optional<Product> findByProductId(final long productId);
 
 }

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockProductRepository.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockProductRepository.java
@@ -17,8 +17,8 @@ public class MockProductRepository implements ProductRepository {
     public static final String DESCRIPTION = "productDescription";
     public static final String PRICE = "10000";
     public static final long QUANTITY = 10L;
-    public static final LocalDateTime START_TIME = LocalDateTime.of(2023, 8, 5, 12, 30);
-    public static final LocalDateTime END_TIME = LocalDateTime.of(2023, 8, 5, 14, 30);
+    public static final LocalDateTime START_TIME = LocalDateTime.now().minusHours(1);
+    public static final LocalDateTime END_TIME = LocalDateTime.now().plusHours(1);
     public static final LocalDateTime INFINITE_START_TIME = LocalDateTime.of(2030, 12, 1, 23, 59);
     public static final LocalDateTime INFINITE_END_TIME = LocalDateTime.of(2030, 12, 31, 23, 59);
     private static final String OFFSET_ID = "+09:00";

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductConnectorService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductConnectorService.java
@@ -1,10 +1,9 @@
 package shop.woowasap.shop.service;
 
-import java.text.MessageFormat;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shop.woowasap.shop.app.api.ProductConnector;
-import shop.woowasap.shop.app.exception.CannotFindProductException;
 import shop.woowasap.shop.app.product.Product;
 import shop.woowasap.shop.app.spi.ProductRepository;
 
@@ -15,11 +14,7 @@ public class ProductConnectorService implements ProductConnector {
     private final ProductRepository productRepository;
 
     @Override
-    public Product getByProductId(final long productId) {
-        return productRepository.findById(productId)
-            .orElseThrow(() -> new CannotFindProductException(
-                MessageFormat.format("productId 에 해당하는 Product 가 존재하지 않습니다. productId : \"{0}\"",
-                    productId)
-            ));
+    public Optional<Product> findByProductId(final long productId) {
+        return productRepository.findById(productId);
     }
 }

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductConnectorServiceTest.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductConnectorServiceTest.java
@@ -1,7 +1,6 @@
 package shop.woowasap.shop.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -14,7 +13,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import shop.woowasap.shop.app.api.ProductConnector;
-import shop.woowasap.shop.app.exception.CannotFindProductException;
 import shop.woowasap.shop.app.product.Product;
 import shop.woowasap.shop.app.spi.ProductRepository;
 import shop.woowasap.shop.service.support.fixture.ProductFixture;
@@ -31,8 +29,8 @@ class ProductConnectorServiceTest {
     private ProductRepository productRepository;
 
     @Nested
-    @DisplayName("getByProductId 메소드는")
-    class getByProductIdMethod {
+    @DisplayName("findByProductId 메소드는")
+    class findByProductIdMethod {
 
         @Test
         @DisplayName("productId를 받아 Product를 반환한다.")
@@ -45,27 +43,28 @@ class ProductConnectorServiceTest {
                 .thenReturn(Optional.of(ProductFixture.validProduct(productId)));
 
             // when
-            final Product result = productConnector.getByProductId(productId);
+            final Optional<Product> result = productConnector.findByProductId(productId);
 
             // then
-            assertThat(result).usingRecursiveAssertion()
+            assertThat(result).isPresent();
+            assertThat(result.get()).usingRecursiveAssertion()
                 .ignoringFieldsMatchingRegexes("id")
                 .isEqualTo(expected);
         }
 
         @Test
-        @DisplayName("productId에 해당하는 Product를 찾을 수 없으면, CannotFindProductException를 던진다.")
-        void throwCannotFindProductExceptionWhenCannotFindMatchedProduct() {
+        @DisplayName("productId에 해당하는 Product를 찾을 수 없으면, Optional.empty를 반환한다.")
+        void returnEmptyOptionalWhenCannotFindMatchedProduct() {
             // given
             final long productId = 1L;
 
             when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
             // when
-            final Exception result = catchException(() -> productConnector.getByProductId(productId));
+            final Optional<Product> result = productConnector.findByProductId(productId);
 
             // then
-            assertThat(result).isInstanceOf(CannotFindProductException.class);
+            assertThat(result).isEmpty();
         }
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
ProductConnect의 시그니처를 변경했으며, 관련 예외 케이스를 추가했습니다.
ProductController에서 exceptionHandler를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] ProductConnector 시그니처 변경 `Product getByProductId` -> `Optional<Product> findByProductId` 
- [x] OrderService 수정 및 예외 테스트 추가
- [x] OrderController에 BadRequest 핸들러 추가

## 🦀 이슈 넘버
- resolve #57 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
