### PR TITLE
feat: Order 도메인에 createdAt 추가

### DIFF
--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/Order.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/Order.java
@@ -1,6 +1,7 @@
 package shop.woowasap.order.domain;
 
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import lombok.Builder;
@@ -14,6 +15,7 @@ public class Order {
     private final long userId;
     private final List<OrderProduct> orderProducts;
     private final BigInteger totalPrice;
+    private final Instant createdAt;
 
     @Builder
     private Order(final long id, final long userId, final List<OrderProduct> orderProducts) {
@@ -22,6 +24,7 @@ public class Order {
         this.userId = userId;
         this.orderProducts = orderProducts;
         this.totalPrice = calculatePrice();
+        this.createdAt = Instant.now();
     }
 
     private void validOrderProducts(final List<OrderProduct> orderProducts) {
@@ -32,8 +35,8 @@ public class Order {
 
     private BigInteger calculatePrice() {
         return orderProducts.stream()
-                .map(OrderProduct::getPrice)
-                .reduce(BigInteger::add)
-                .orElseThrow(IllegalStateException::new);
+            .map(OrderProduct::getPrice)
+            .reduce(BigInteger::add)
+            .orElseThrow(IllegalStateException::new);
     }
 }

--- a/order/order-domain/src/test/java/shop/woowasap/order/domain/OrderTest.java
+++ b/order/order-domain/src/test/java/shop/woowasap/order/domain/OrderTest.java
@@ -34,7 +34,9 @@ class OrderTest {
                     .build();
 
             // then
-            assertThat(order).usingRecursiveComparison().isEqualTo(expected);
+            assertThat(order).usingRecursiveComparison()
+                .ignoringFields("createdAt")
+                .isEqualTo(expected);
         }
 
         @Test


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
Order 도메인에 createdAt을 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] Order 도메인에 createdAt 추가
- [x] 테스트 수정

## 🦀 이슈 넘버
- resolve #59 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
