### PR TITLE
feat: OrderService.getOrderByUserId 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -10,9 +10,9 @@ import shop.woowasap.accept.support.api.OrderApiSupporter;
 import shop.woowasap.accept.support.api.ShopApiSupporter;
 import shop.woowasap.accept.support.valid.HttpValidator;
 import shop.woowasap.accept.support.valid.OrderValidator;
-import shop.woowasap.mock.dto.OrderProductResponse;
-import shop.woowasap.mock.dto.OrderResponse;
-import shop.woowasap.mock.dto.OrdersResponse;
+import shop.woowasap.order.domain.in.response.OrderProductResponse;
+import shop.woowasap.order.domain.in.response.OrderResponse;
+import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.mock.dto.ProductsResponse;
 import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
 

--- a/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
-import shop.woowasap.mock.dto.OrdersResponse;
+import shop.woowasap.order.domain.in.response.OrdersResponse;
 
 public final class OrderValidator {
 

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
@@ -1,9 +1,11 @@
 package shop.woowasap.order.domain.in;
 
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
+import shop.woowasap.order.domain.in.response.OrdersResponse;
 
 public interface OrderUseCase {
 
     long orderProduct(final OrderProductRequest orderProductRequest);
 
+    OrdersResponse getOrderByUserId(final long userId, final int page, final int size);
 }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderProductResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderProductResponse.java
@@ -1,4 +1,4 @@
-package shop.woowasap.mock.dto;
+package shop.woowasap.order.domain.in.response;
 
 public record OrderProductResponse(long productId, String name) {
 

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderResponse.java
@@ -1,4 +1,4 @@
-package shop.woowasap.mock.dto;
+package shop.woowasap.order.domain.in.response;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrdersResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrdersResponse.java
@@ -1,4 +1,4 @@
-package shop.woowasap.mock.dto;
+package shop.woowasap.order.domain.in.response;
 
 import java.util.List;
 

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/out/OrderRepository.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/out/OrderRepository.java
@@ -1,8 +1,12 @@
 package shop.woowasap.order.domain.out;
 
 import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.out.response.OrdersPaginationResponse;
 
 public interface OrderRepository {
 
-    void persist(Order order);
+    void persist(final Order order);
+
+    OrdersPaginationResponse findAllOrderByUserId(final long userId, final int page,
+        final int size);
 }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/out/response/OrdersPaginationResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/out/response/OrdersPaginationResponse.java
@@ -1,0 +1,8 @@
+package shop.woowasap.order.domain.out.response;
+
+import java.util.List;
+import shop.woowasap.order.domain.Order;
+
+public record OrdersPaginationResponse(List<Order> orders, int page, int totalPage) {
+
+}

--- a/order/order-repository/src/main/java/shop/woowasap/order/repository/MockOrderRepository.java
+++ b/order/order-repository/src/main/java/shop/woowasap/order/repository/MockOrderRepository.java
@@ -1,13 +1,21 @@
 package shop.woowasap.order.repository;
 
+import java.util.Collections;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.out.OrderRepository;
+import shop.woowasap.order.domain.out.response.OrdersPaginationResponse;
 
 @Repository
 public class MockOrderRepository implements OrderRepository {
 
     @Override
     public void persist(final Order order) {
+    }
+
+    @Override
+    public OrdersPaginationResponse findAllOrderByUserId(final long userId, final int page, final int size) {
+        return null;
     }
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -1,16 +1,24 @@
 package shop.woowasap.order.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.OrderProduct;
 import shop.woowasap.order.domain.exception.DoesNotFindProductException;
 import shop.woowasap.order.domain.exception.DoesNotOrderedException;
 import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
+import shop.woowasap.order.domain.in.response.OrderProductResponse;
+import shop.woowasap.order.domain.in.response.OrderResponse;
+import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.order.domain.out.OrderRepository;
 import shop.woowasap.order.domain.out.Payment;
+import shop.woowasap.order.domain.out.response.OrdersPaginationResponse;
 import shop.woowasap.order.service.mapper.OrderMapper;
 import shop.woowasap.shop.domain.api.product.ProductConnector;
 import shop.woowasap.shop.domain.product.Product;
@@ -25,12 +33,15 @@ public class OrderService implements OrderUseCase {
     private final ProductConnector productConnector;
     private final OrderRepository orderRepository;
 
+    @Value("${shop.woowasap.locale:Asia/Seoul}")
+    private String locale;
+
     @Override
     @Transactional
     public long orderProduct(final OrderProductRequest orderProductRequest) {
-        final Product product = productConnector.findByProductId(orderProductRequest.productId())
-            .orElseThrow(() -> new DoesNotFindProductException(orderProductRequest.productId()));
-        final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest.userId(), product);
+        final Product product = getProductByProductId(orderProductRequest.productId());
+        final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest.userId(),
+            product);
 
         if (!payment.pay(orderProductRequest.userId())) {
             throw new DoesNotOrderedException();
@@ -38,5 +49,48 @@ public class OrderService implements OrderUseCase {
 
         orderRepository.persist(order);
         return order.getId();
+    }
+
+    @Override
+    public OrdersResponse getOrderByUserId(final long userId, final int page, final int size) {
+        final OrdersPaginationResponse ordersPaginationResponse = orderRepository.findAllOrderByUserId(
+            userId, page, size);
+        final List<Order> orders = ordersPaginationResponse.orders();
+
+        final List<OrderResponse> orderResponses = getOrderResponse(orders);
+
+        return OrderMapper.toOrdersResponse(orderResponses, ordersPaginationResponse.page(),
+            ordersPaginationResponse.totalPage());
+    }
+
+    private List<OrderResponse> getOrderResponse(final List<Order> orders) {
+        final List<OrderResponse> orderResponses = new ArrayList<>();
+
+        for (Order order : orders) {
+            final List<OrderProductResponse> orderProductResponses = getOrderProductResponse(order);
+
+            final OrderResponse orderResponse = OrderMapper.toOrderResponse(order, orderProductResponses,
+                locale);
+
+            orderResponses.add(orderResponse);
+        }
+
+        return orderResponses;
+    }
+
+    private List<OrderProductResponse> getOrderProductResponse(final Order order) {
+        final List<OrderProductResponse> orderProductResponses = new ArrayList<>();
+        for (OrderProduct orderProduct : order.getOrderProducts()) {
+            final Product product = getProductByProductId(orderProduct.getProductId());
+            final OrderProductResponse orderProductResponse = OrderMapper.toOrderProductResponse(
+                product);
+            orderProductResponses.add(orderProductResponse);
+        }
+        return orderProductResponses;
+    }
+
+    private Product getProductByProductId(final long productId) {
+        return productConnector.findByProductId(productId)
+            .orElseThrow(() -> new DoesNotFindProductException(productId));
     }
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -1,6 +1,5 @@
 package shop.woowasap.order.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.order.domain.Order;
-import shop.woowasap.order.domain.OrderProduct;
 import shop.woowasap.order.domain.exception.DoesNotFindProductException;
 import shop.woowasap.order.domain.exception.DoesNotOrderedException;
 import shop.woowasap.order.domain.in.OrderUseCase;
@@ -64,29 +62,18 @@ public class OrderService implements OrderUseCase {
     }
 
     private List<OrderResponse> getOrderResponse(final List<Order> orders) {
-        final List<OrderResponse> orderResponses = new ArrayList<>();
-
-        for (Order order : orders) {
-            final List<OrderProductResponse> orderProductResponses = getOrderProductResponse(order);
-
-            final OrderResponse orderResponse = OrderMapper.toOrderResponse(order, orderProductResponses,
-                locale);
-
-            orderResponses.add(orderResponse);
-        }
-
-        return orderResponses;
+        return orders.stream()
+            .map(
+                order -> OrderMapper.toOrderResponse(order, getOrderProductResponse(order), locale))
+            .toList();
     }
 
     private List<OrderProductResponse> getOrderProductResponse(final Order order) {
-        final List<OrderProductResponse> orderProductResponses = new ArrayList<>();
-        for (OrderProduct orderProduct : order.getOrderProducts()) {
-            final Product product = getProductByProductId(orderProduct.getProductId());
-            final OrderProductResponse orderProductResponse = OrderMapper.toOrderProductResponse(
-                product);
-            orderProductResponses.add(orderProductResponse);
-        }
-        return orderProductResponses;
+        return order.getOrderProducts()
+            .stream()
+            .map(orderProduct -> OrderMapper.toOrderProductResponse(
+                getProductByProductId(orderProduct.getProductId())))
+            .toList();
     }
 
     private Product getProductByProductId(final long productId) {

--- a/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
@@ -1,9 +1,14 @@
 package shop.woowasap.order.service.mapper;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.OrderProduct;
+import shop.woowasap.order.domain.in.response.OrderProductResponse;
+import shop.woowasap.order.domain.in.response.OrderResponse;
+import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.shop.domain.product.Product;
 
 public final class OrderMapper {
@@ -12,19 +17,37 @@ public final class OrderMapper {
         throw new UnsupportedOperationException("Cannot invoke constructor \"OrderMapper()\"");
     }
 
-    public static Order toDomain(final IdGenerator idGenerator, final long userId, final Product product) {
+    public static Order toDomain(final IdGenerator idGenerator, final long userId,
+        final Product product) {
         return Order.builder()
-                .id(idGenerator.generate())
-                .userId(userId)
-                .orderProducts(List.of(OrderProduct
-                        .builder()
-                        .productId(product.getId())
-                        .price(product.getPrice().getValue().toString())
-                        .quantity(product.getQuantity().getValue())
-                        .startTime(product.getStartTime())
-                        .endTime(product.getEndTime())
-                        .build()))
-                .build();
+            .id(idGenerator.generate())
+            .userId(userId)
+            .orderProducts(List.of(OrderProduct
+                .builder()
+                .productId(product.getId())
+                .price(product.getPrice().getValue().toString())
+                .quantity(product.getQuantity().getValue())
+                .startTime(product.getStartTime())
+                .endTime(product.getEndTime())
+                .build()))
+            .build();
     }
 
+    public static OrderProductResponse toOrderProductResponse(Product product) {
+        return new OrderProductResponse(product.getId(), product.getName().getValue());
+    }
+
+    public static OrderResponse toOrderResponse(Order order,
+        List<OrderProductResponse> orderProductResponses, String locale) {
+
+        return new OrderResponse(order.getId(), orderProductResponses,
+            order.getTotalPrice().toString(), order.getOrderProducts().size(),
+            LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
+    }
+
+    public static OrdersResponse toOrdersResponse(final List<OrderResponse> orderResponses,
+        final int page, final int totalPage) {
+
+        return new OrdersResponse(orderResponses, page, totalPage);
+    }
 }

--- a/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
@@ -4,24 +4,34 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import shop.woowasap.core.id.api.IdGenerator;
+import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.OrderProduct;
 import shop.woowasap.order.domain.exception.DoesNotFindProductException;
 import shop.woowasap.order.domain.exception.DoesNotOrderedException;
 import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
+import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.order.domain.out.OrderRepository;
 import shop.woowasap.order.domain.out.Payment;
+import shop.woowasap.order.domain.out.response.OrdersPaginationResponse;
+import shop.woowasap.order.service.support.fixture.OrderDtoFixture;
+import shop.woowasap.order.service.support.fixture.OrderFixture;
+import shop.woowasap.order.service.support.fixture.OrderProductFixture;
 import shop.woowasap.order.service.support.fixture.ProductFixture;
 import shop.woowasap.shop.domain.api.product.ProductConnector;
+import shop.woowasap.shop.domain.product.Product;
 
 @DisplayName("OrderService 클래스")
 @ExtendWith(SpringExtension.class)
@@ -54,11 +64,13 @@ class OrderServiceTest {
             final long userId = 1L;
             final long productId = 2L;
             final int quantity = 3;
-            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId, productId, quantity);
+            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId,
+                productId, quantity);
 
             final long orderId = 1L;
             when(idGenerator.generate()).thenReturn(orderId);
-            when(productConnector.findByProductId(productId)).thenReturn(Optional.of(ProductFixture.getDefaultBuilder()
+            when(productConnector.findByProductId(productId)).thenReturn(
+                Optional.of(ProductFixture.getDefaultBuilder()
                     .build()));
             when(payment.pay(userId)).thenReturn(true);
 
@@ -76,16 +88,19 @@ class OrderServiceTest {
             final long userId = 1L;
             final long productId = 2L;
             final int quantity = 3;
-            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId, productId, quantity);
+            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId,
+                productId, quantity);
 
             final long orderId = 1L;
             when(idGenerator.generate()).thenReturn(orderId);
-            when(productConnector.findByProductId(productId)).thenReturn(Optional.of(ProductFixture.getDefaultBuilder()
+            when(productConnector.findByProductId(productId)).thenReturn(
+                Optional.of(ProductFixture.getDefaultBuilder()
                     .build()));
             when(payment.pay(userId)).thenReturn(false);
 
             // when
-            final Exception exception = catchException(() -> orderUseCase.orderProduct(orderProductRequest));
+            final Exception exception = catchException(
+                () -> orderUseCase.orderProduct(orderProductRequest));
 
             // then
             assertThat(exception).isInstanceOf(DoesNotOrderedException.class);
@@ -98,15 +113,93 @@ class OrderServiceTest {
             final long userId = 1L;
             final long productId = 2L;
             final int quantity = 3;
-            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId, productId, quantity);
+            final OrderProductRequest orderProductRequest = new OrderProductRequest(userId,
+                productId, quantity);
 
             when(productConnector.findByProductId(productId)).thenReturn(Optional.empty());
 
             // when
-            final Exception exception = catchException(() -> orderUseCase.orderProduct(orderProductRequest));
+            final Exception exception = catchException(
+                () -> orderUseCase.orderProduct(orderProductRequest));
 
             // then
             assertThat(exception).isInstanceOf(DoesNotFindProductException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrderByUserId 메소드는")
+    class getOrderByUserIdMethod {
+
+        @Test
+        @DisplayName("userId와 page, totalPage에 해당하는 모든 주문목록을 조회한다.")
+        void returnAllOrdersResponseMatchedUserIdAndPageAndTotalPage() {
+            // given
+            final long userId = 1L;
+            final int page = 1;
+            final int size = 1;
+
+            final Product product = ProductFixture.getDefaultBuilder().build();
+            final OrderProduct orderProduct = OrderProductFixture.from(product);
+            final Order defaultOrder = OrderFixture.getDefault(List.of(orderProduct));
+
+            when(orderRepository.findAllOrderByUserId(userId, page, size)).thenReturn(
+                new OrdersPaginationResponse(List.of(defaultOrder), page, size));
+
+            when(productConnector.findByProductId(product.getId())).thenReturn(
+                Optional.of(product));
+
+            final OrdersResponse expected = OrderDtoFixture.from(List.of(defaultOrder), "Asia/Seoul",
+                page, size, product.getName().getValue());
+
+            // when
+            final OrdersResponse result = orderUseCase.getOrderByUserId(userId, page, size);
+
+            // then
+            assertThat(result).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("productId에 해당하는 product를 찾을 수 없으면 DoesNotFindProductException를 던진다.")
+        void throwDoesNotFindProductExceptionWhenCannotFindMatchedProduct() {
+            // given
+            final long userId = 1L;
+            final int page = 1;
+            final int size = 1;
+
+            final Product product = ProductFixture.getDefaultBuilder().build();
+            final OrderProduct orderProduct = OrderProductFixture.from(product);
+            final Order defaultOrder = OrderFixture.getDefault(List.of(orderProduct));
+
+            when(orderRepository.findAllOrderByUserId(userId, page, size)).thenReturn(
+                new OrdersPaginationResponse(List.of(defaultOrder), page, size));
+
+            when(productConnector.findByProductId(Mockito.anyLong())).thenReturn(Optional.empty());
+
+            // when
+            final Exception result = catchException(
+                () -> orderUseCase.getOrderByUserId(userId, page, size));
+
+            // then
+            assertThat(result).isInstanceOf(DoesNotFindProductException.class);
+        }
+
+        @Test
+        @DisplayName("userId에 해당하는 user가 주문한 상품이 없다면 빈 Order가 반환된다.")
+        void returnEmptyOrdersWhenNoExistOrderHistory() {
+            // given
+            final long userId = 1L;
+            final int page = 1;
+            final int size = 1;
+
+            when(orderRepository.findAllOrderByUserId(userId, page, size)).thenReturn(
+                new OrdersPaginationResponse(List.of(), page, size));
+
+            // when
+            final OrdersResponse result = orderUseCase.getOrderByUserId(userId, page, size);
+
+            // then
+            assertThat(result.orders()).isEmpty();
         }
     }
 }

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
@@ -2,10 +2,8 @@ package shop.woowasap.order.service.support.fixture;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.List;
 import shop.woowasap.order.domain.Order;
-import shop.woowasap.order.domain.OrderProduct;
 import shop.woowasap.order.domain.in.response.OrderProductResponse;
 import shop.woowasap.order.domain.in.response.OrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
@@ -24,31 +22,23 @@ public final class OrderDtoFixture {
         return new OrdersResponse(orderResponses, page, totalPage);
     }
 
-    private static List<OrderResponse> getOrderResponse(final List<Order> orders, final String locale, final String fixedName) {
-        final List<OrderResponse> orderResponses = new ArrayList<>();
+    private static List<OrderResponse> getOrderResponse(final List<Order> orders,
+        final String locale, final String fixedName) {
 
-        for (Order order : orders) {
-            final List<OrderProductResponse> orderProductResponses = getOrderProductResponse(order, fixedName);
-
-            final OrderResponse orderResponse = new OrderResponse(order.getId(),
-                orderProductResponses,
+        return orders.stream()
+            .map(order -> new OrderResponse(order.getId(),
+                getOrderProductResponse(order, fixedName),
                 order.getTotalPrice().toString(), order.getOrderProducts().size(),
-                LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
-
-            orderResponses.add(orderResponse);
-        }
-
-        return orderResponses;
+                LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale))))
+            .toList();
     }
 
-    private static List<OrderProductResponse> getOrderProductResponse(final Order order, final String fixedName) {
-        final List<OrderProductResponse> orderProductResponses = new ArrayList<>();
-        for (OrderProduct orderProduct : order.getOrderProducts()) {
-            final OrderProductResponse orderProductResponse = new OrderProductResponse(
-                orderProduct.getProductId(), fixedName);
+    private static List<OrderProductResponse> getOrderProductResponse(final Order order,
+        final String fixedName) {
 
-            orderProductResponses.add(orderProductResponse);
-        }
-        return orderProductResponses;
+        return order.getOrderProducts()
+            .stream()
+            .map(orderProduct -> new OrderProductResponse(orderProduct.getProductId(), fixedName))
+            .toList();
     }
 }

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
@@ -1,0 +1,54 @@
+package shop.woowasap.order.service.support.fixture;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.OrderProduct;
+import shop.woowasap.order.domain.in.response.OrderProductResponse;
+import shop.woowasap.order.domain.in.response.OrderResponse;
+import shop.woowasap.order.domain.in.response.OrdersResponse;
+
+public final class OrderDtoFixture {
+
+    private OrderDtoFixture() {
+        throw new UnsupportedOperationException("Cannot invoke constructor \"OrderDtoFixture()\"");
+    }
+
+    public static OrdersResponse from(final List<Order> orders, final String locale, final int page,
+        final int totalPage, final String fixedName) {
+
+        final List<OrderResponse> orderResponses = getOrderResponse(orders, locale, fixedName);
+
+        return new OrdersResponse(orderResponses, page, totalPage);
+    }
+
+    private static List<OrderResponse> getOrderResponse(final List<Order> orders, final String locale, final String fixedName) {
+        final List<OrderResponse> orderResponses = new ArrayList<>();
+
+        for (Order order : orders) {
+            final List<OrderProductResponse> orderProductResponses = getOrderProductResponse(order, fixedName);
+
+            final OrderResponse orderResponse = new OrderResponse(order.getId(),
+                orderProductResponses,
+                order.getTotalPrice().toString(), order.getOrderProducts().size(),
+                LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
+
+            orderResponses.add(orderResponse);
+        }
+
+        return orderResponses;
+    }
+
+    private static List<OrderProductResponse> getOrderProductResponse(final Order order, final String fixedName) {
+        final List<OrderProductResponse> orderProductResponses = new ArrayList<>();
+        for (OrderProduct orderProduct : order.getOrderProducts()) {
+            final OrderProductResponse orderProductResponse = new OrderProductResponse(
+                orderProduct.getProductId(), fixedName);
+
+            orderProductResponses.add(orderProductResponse);
+        }
+        return orderProductResponses;
+    }
+}

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderFixture.java
@@ -1,0 +1,23 @@
+package shop.woowasap.order.service.support.fixture;
+
+import java.util.List;
+import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.OrderProduct;
+
+public final class OrderFixture {
+
+    private static final long DEFAULT_ID = 1L;
+    private static final long DEFAULT_USER_ID = 1L;
+
+    private OrderFixture() {
+        throw new UnsupportedOperationException("Cannot invoke constructor \"OrderFixture()\"");
+    }
+
+    public static Order getDefault(final List<OrderProduct> orderProducts) {
+        return Order.builder()
+            .id(DEFAULT_ID)
+            .userId(DEFAULT_USER_ID)
+            .orderProducts(orderProducts)
+            .build();
+    }
+}

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderProductFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderProductFixture.java
@@ -1,0 +1,21 @@
+package shop.woowasap.order.service.support.fixture;
+
+import shop.woowasap.order.domain.OrderProduct;
+import shop.woowasap.shop.domain.product.Product;
+
+public final class OrderProductFixture {
+
+    private OrderProductFixture() {
+        throw new UnsupportedOperationException("Cannot invoke constructor \"OrderProductFixture()\"");
+    }
+
+    public static OrderProduct from(final Product product) {
+        return OrderProduct.builder()
+            .productId(product.getId())
+            .startTime(product.getStartTime())
+            .endTime(product.getEndTime())
+            .price(String.valueOf(product.getPrice().getValue()))
+            .quantity(product.getQuantity().getValue())
+            .build();
+    }
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
OrderService.getOrderByUserId 메소드를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] userId, page, size 를 받아 OrdersResponse를 반환하는 OrderService 메소드 추가
- [x] 아무것도 찾을 수 없다면 빈 OrdersResponse 반환
- [x] product를 찾을 수 없다면, DoesNotFindProductException 를 던짐

## 🦀 이슈 넘버
- resolve #59

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
