### PR TITLE
feat: MockOrderRepository.findAllOrderByUserId 구현

### DIFF
--- a/order/order-repository/src/main/java/shop/woowasap/order/repository/MockOrderRepository.java
+++ b/order/order-repository/src/main/java/shop/woowasap/order/repository/MockOrderRepository.java
@@ -1,7 +1,8 @@
 package shop.woowasap.order.repository;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Repository;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.out.OrderRepository;
@@ -10,12 +11,18 @@ import shop.woowasap.order.domain.out.response.OrdersPaginationResponse;
 @Repository
 public class MockOrderRepository implements OrderRepository {
 
+    private final Map<Long, Order> userIdPerOrderRepository = new HashMap<>();
+
     @Override
     public void persist(final Order order) {
+        userIdPerOrderRepository.put(order.getUserId(), order);
     }
 
     @Override
-    public OrdersPaginationResponse findAllOrderByUserId(final long userId, final int page, final int size) {
-        return null;
+    public OrdersPaginationResponse findAllOrderByUserId(final long userId, final int page,
+        final int size) {
+
+        return new OrdersPaginationResponse(List.of(userIdPerOrderRepository.get(userId)), page,
+            size);
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
MockOrderRepository의 findAllOrderByUserId를 구현했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] MockOrderRepository가 저장된 userId에 해당 하는 Order를 반환하도록 구현

## 🦀 이슈 넘버
- resolve #59 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
