### PR TITLE
test: 특정 Order 조회 인수테스트 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -105,9 +105,9 @@ class OrderAcceptanceTest extends AcceptanceTest {
         final long orderId = ordersResponse.orders().get(0).orderId();
 
         final DetailOrderProductResponse expectedDetailOrderProductResponse =
-            new DetailOrderProductResponse(product.productId(), product.name());
+            new DetailOrderProductResponse(product.productId(), product.name(), product.price(), quantity);
         final DetailOrderResponse expectedDetailOrderResponse = new DetailOrderResponse(orderId, List.of(expectedDetailOrderProductResponse),
-            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(), 1, LocalDateTime.now());
+            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(), LocalDateTime.now());
 
         // when
         final ExtractableResponse<Response> result = OrderApiSupporter.getOrderByOrderId(orderId, token);

--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -11,6 +11,8 @@ import shop.woowasap.accept.support.api.OrderApiSupporter;
 import shop.woowasap.accept.support.api.ShopApiSupporter;
 import shop.woowasap.accept.support.valid.HttpValidator;
 import shop.woowasap.accept.support.valid.OrderValidator;
+import shop.woowasap.mock.dto.DetailOrderProductResponse;
+import shop.woowasap.mock.dto.DetailOrderResponse;
 import shop.woowasap.mock.dto.ProductsResponse;
 import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
 import shop.woowasap.order.domain.in.response.OrderProductResponse;
@@ -85,6 +87,47 @@ class OrderAcceptanceTest extends AcceptanceTest {
 
         // then
         OrderValidator.assertOrders(result, expected);
+    }
+
+    @Test
+    @DisplayName("특정 구매내역 조회 API는 사용자의 구매내역을 응답한다.")
+    void returnDetailOrders() {
+        // given
+        final String token = "TOKEN";
+        final ProductsResponse.Product product = getRandomProduct();
+        final long quantity = 10;
+        final OrderProductQuantityRequest orderProductQuantityRequest = new OrderProductQuantityRequest(
+            quantity);
+        OrderApiSupporter.orderProduct(product.productId(), orderProductQuantityRequest, token);
+
+        final OrdersResponse ordersResponse = OrderApiSupporter.getAllProducts(token)
+            .as(OrdersResponse.class);
+        final long orderId = ordersResponse.orders().get(0).orderId();
+
+        final DetailOrderProductResponse expectedDetailOrderProductResponse =
+            new DetailOrderProductResponse(product.productId(), product.name());
+        final DetailOrderResponse expectedDetailOrderResponse = new DetailOrderResponse(orderId, List.of(expectedDetailOrderProductResponse),
+            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(), 1, LocalDateTime.now());
+
+        // when
+        final ExtractableResponse<Response> result = OrderApiSupporter.getOrderByOrderId(orderId, token);
+
+        // then
+        OrderValidator.assertOrder(result, expectedDetailOrderResponse);
+    }
+
+    @Test
+    @DisplayName("특정 구매내역 조회 API는 orderId에 해당하는 Order를 찾을 수 없는경우 400 Bad Request 를 반환한다.")
+    void returnBadRequestWhenCannotFindMatchedOrderByOrderId() {
+        // given
+        final String token = "TOKEN";
+        final long invalidOrderId = 999L;
+
+        // when
+        final ExtractableResponse<Response> result = OrderApiSupporter.getOrderByOrderId(invalidOrderId, token);
+
+        // then
+        HttpValidator.assertBadRequest(result);
     }
 
     private ProductsResponse.Product getRandomProduct() {

--- a/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/OrderApiSupporter.java
@@ -14,21 +14,22 @@ public final class OrderApiSupporter {
     private static final String API_VERSION = "v1";
 
     private OrderApiSupporter() {
-        throw new UnsupportedOperationException("Cannot invoke constructor \"OrderApiSupporter()\"");
+        throw new UnsupportedOperationException(
+            "Cannot invoke constructor \"OrderApiSupporter()\"");
     }
 
     public static ExtractableResponse<Response> orderProduct(final long productId,
-            final OrderProductQuantityRequest orderProductRequest, final String token) {
+        final OrderProductQuantityRequest orderProductRequest, final String token) {
 
         return given().log().all()
-                .contentType(JSON)
-                .accept(JSON)
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .body(orderProductRequest)
-                .when().log().all()
-                .post(API_VERSION + "/orders/products/{product-id}", productId)
-                .then().log().all()
-                .extract();
+            .contentType(JSON)
+            .accept(JSON)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .body(orderProductRequest)
+            .when().log().all()
+            .post(API_VERSION + "/orders/products/{product-id}", productId)
+            .then().log().all()
+            .extract();
     }
 
     public static ExtractableResponse<Response> getAllProducts(final String token) {
@@ -39,6 +40,19 @@ public final class OrderApiSupporter {
             .header(HttpHeaders.AUTHORIZATION, token)
             .when().log().all()
             .get(API_VERSION + "/orders")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> getOrderByOrderId(final long orderId,
+        final String token) {
+
+        return given().log().all()
+            .contentType(JSON)
+            .accept(JSON)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .when().log().all()
+            .get(API_VERSION + "/orders/{order-id}", orderId)
             .then().log().all()
             .extract();
     }

--- a/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
+import shop.woowasap.mock.dto.DetailOrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 
 public final class OrderValidator {
@@ -26,6 +27,18 @@ public final class OrderValidator {
 
         assertThat(ordersResult).usingRecursiveComparison()
             .ignoringFields("orders.createdAt", "orders.orderId")
+            .isEqualTo(expected);
+    }
+
+    public static void assertOrder(ExtractableResponse<Response> result,
+        DetailOrderResponse expected) {
+
+        HttpValidator.assertOk(result);
+
+        DetailOrderResponse detailOrderResult = result.as(DetailOrderResponse.class);
+
+        assertThat(detailOrderResult).usingRecursiveComparison()
+            .ignoringFields("createdAt")
             .isEqualTo(expected);
     }
 }

--- a/app/src/test/java/shop/woowasap/mock/dto/DetailOrderProductResponse.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/DetailOrderProductResponse.java
@@ -1,0 +1,5 @@
+package shop.woowasap.mock.dto;
+
+public record DetailOrderProductResponse(long productId, String name) {
+
+}

--- a/app/src/test/java/shop/woowasap/mock/dto/DetailOrderProductResponse.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/DetailOrderProductResponse.java
@@ -1,5 +1,5 @@
 package shop.woowasap.mock.dto;
 
-public record DetailOrderProductResponse(long productId, String name) {
+public record DetailOrderProductResponse(long productId, String name, String price, long quantity) {
 
 }

--- a/app/src/test/java/shop/woowasap/mock/dto/DetailOrderResponse.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/DetailOrderResponse.java
@@ -4,6 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record DetailOrderResponse(long orderId, List<DetailOrderProductResponse> products,
-                                  String price, long quantity, LocalDateTime createdAt) {
+                                  String totalPrice, LocalDateTime createdAt) {
 
 }

--- a/app/src/test/java/shop/woowasap/mock/dto/DetailOrderResponse.java
+++ b/app/src/test/java/shop/woowasap/mock/dto/DetailOrderResponse.java
@@ -1,0 +1,9 @@
+package shop.woowasap.mock.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DetailOrderResponse(long orderId, List<DetailOrderProductResponse> products,
+                                  String price, long quantity, LocalDateTime createdAt) {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
특정 주문 내역을 조회하는 인수테스트를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] orderId와 사용자 토큰을 받아 주문내역을 조회하는 인수테스트 추가
- [x] orderId에 해당하는 주문내역이 없을경우, `400 Bad Request` 를 검증하는 인수테스트 추가

## 🦀 이슈 넘버
- resolve #56

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
