### PR TITLE
feat: `/v1/orders/{order-id}` API 핸들러 추가

### DIFF
--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -68,7 +68,7 @@ public class OrderController {
         InvalidProductSaleTimeException.class,
         InvalidQuantityException.class,
         DoesNotFindOrderException.class})
-    private ResponseEntity<Void> handleBadRequest(RuntimeException runtimeException) {
+    private ResponseEntity<Void> handleBadRequest(final RuntimeException runtimeException) {
         return ResponseEntity.badRequest().build();
     }
 }

--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
+import shop.woowasap.order.domain.exception.DoesNotFindOrderException;
 import shop.woowasap.order.domain.exception.DoesNotFindProductException;
 import shop.woowasap.order.domain.exception.DoesNotOrderedException;
 import shop.woowasap.order.domain.exception.InvalidOrderProductException;
@@ -20,6 +21,7 @@ import shop.woowasap.order.domain.exception.InvalidProductSaleTimeException;
 import shop.woowasap.order.domain.exception.InvalidQuantityException;
 import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
+import shop.woowasap.order.domain.in.response.DetailOrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 
 @RestController
@@ -45,11 +47,18 @@ public class OrderController {
     }
 
     @GetMapping
-    public ResponseEntity<OrdersResponse> getOrderByUserId(
+    public ResponseEntity<OrdersResponse> getOrdersByUserId(
         @RequestParam(defaultValue = "1") final int page,
         @RequestParam(defaultValue = "20") final int size) {
 
         return ResponseEntity.ok(orderUseCase.getOrderByUserId(MOCK_USER_ID, page, size));
+    }
+
+    @GetMapping("/{order-id}")
+    public ResponseEntity<DetailOrderResponse> getOrderByOrderIdAndUserID(
+        @PathVariable("order-id") final long orderId) {
+
+        return ResponseEntity.ok(orderUseCase.getOrderByOrderIdAndUserId(orderId, MOCK_USER_ID));
     }
 
     @ExceptionHandler({DoesNotFindProductException.class,
@@ -57,7 +66,8 @@ public class OrderController {
         InvalidOrderProductException.class,
         InvalidPriceException.class,
         InvalidProductSaleTimeException.class,
-        InvalidQuantityException.class})
+        InvalidQuantityException.class,
+        DoesNotFindOrderException.class})
     private ResponseEntity<Void> handleBadRequest(RuntimeException runtimeException) {
         return ResponseEntity.badRequest().build();
     }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
`/v1/orders/{order-id}` 요청을 받는 API 핸들러를 개발했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `orderId`와 `userId`를 받아 OrderResponse를 반환하는 핸들러를 추가했습니다.
- [x] `DoesNotFindOrderException` 예외 핸들러 추가

## 🦀 이슈 넘버
- resolve #56 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
