### PR TITLE
refactor: `GET /v1/orders` API 응답 body 변경

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -11,10 +11,10 @@ import shop.woowasap.accept.support.api.OrderApiSupporter;
 import shop.woowasap.accept.support.api.ShopApiSupporter;
 import shop.woowasap.accept.support.valid.HttpValidator;
 import shop.woowasap.accept.support.valid.OrderValidator;
-import shop.woowasap.order.domain.in.response.DetailOrderProductResponse;
-import shop.woowasap.order.domain.in.response.DetailOrderResponse;
 import shop.woowasap.mock.dto.ProductsResponse;
 import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
+import shop.woowasap.order.domain.in.response.DetailOrderProductResponse;
+import shop.woowasap.order.domain.in.response.DetailOrderResponse;
 import shop.woowasap.order.domain.in.response.OrderProductResponse;
 import shop.woowasap.order.domain.in.response.OrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
@@ -75,11 +75,10 @@ class OrderAcceptanceTest extends AcceptanceTest {
         OrderApiSupporter.orderProduct(product.productId(), orderProductQuantityRequest, token);
 
         final OrderProductResponse expectedOrderProductResponse = new OrderProductResponse(
-            product.productId(), product.name());
+            product.productId(), product.name(), product.price(), quantity);
         final OrderResponse expectedOrderResponse = new OrderResponse(1L,
             List.of(expectedOrderProductResponse),
-            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(),
-            1, LocalDateTime.now());
+            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(), LocalDateTime.now());
         final OrdersResponse expected = new OrdersResponse(List.of(expectedOrderResponse), 1, 20);
 
         // when
@@ -106,7 +105,8 @@ class OrderAcceptanceTest extends AcceptanceTest {
 
         final DetailOrderProductResponse expectedDetailOrderProductResponse =
             new DetailOrderProductResponse(product.productId(), product.name(), product.price(), quantity);
-        final DetailOrderResponse expectedDetailOrderResponse = new DetailOrderResponse(orderId, List.of(expectedDetailOrderProductResponse),
+        final DetailOrderResponse expectedDetailOrderResponse = new DetailOrderResponse(orderId,
+            List.of(expectedDetailOrderProductResponse),
             new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(), LocalDateTime.now());
 
         // when

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/OrderProduct.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/OrderProduct.java
@@ -18,7 +18,7 @@ public class OrderProduct {
 
     @Builder
     private OrderProduct(final long productId, final long quantity, final String price,
-            final Instant startTime, final Instant endTime) {
+        final Instant startTime, final Instant endTime) {
         validPrice(price);
         validQuantity(quantity);
         validateProductSaleTime(startTime, endTime);

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderProductResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderProductResponse.java
@@ -1,5 +1,5 @@
 package shop.woowasap.order.domain.in.response;
 
-public record OrderProductResponse(long productId, String name) {
+public record OrderProductResponse(long productId, String name, String price, long quantity) {
 
 }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderResponse.java
@@ -3,7 +3,7 @@ package shop.woowasap.order.domain.in.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record OrderResponse(long orderId, List<OrderProductResponse> products, String price,
-                            long quantity, LocalDateTime createdAt) {
+public record OrderResponse(long orderId, List<OrderProductResponse> products, String totalPrice,
+                            LocalDateTime createdAt) {
 
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -58,10 +58,20 @@ public class OrderService implements OrderUseCase {
             userId, page, size);
         final List<Order> orders = ordersPaginationResponse.orders();
 
-        final List<OrderResponse> orderResponses = getOrderResponse(orders);
+        final List<OrderResponse> orderResponses = orders.stream()
+            .map(order -> OrderMapper.toOrderResponse(order, getOrderProductResponse(order), locale))
+            .toList();
 
         return OrderMapper.toOrdersResponse(orderResponses, ordersPaginationResponse.page(),
             ordersPaginationResponse.totalPage());
+    }
+
+    private List<OrderProductResponse> getOrderProductResponse(final Order order) {
+        return order.getOrderProducts()
+            .stream()
+            .map(orderProduct -> OrderMapper.toOrderProductResponse(getProductByProductId(orderProduct.getProductId()),
+                orderProduct.getQuantity()))
+            .toList();
     }
 
     @Override
@@ -78,21 +88,6 @@ public class OrderService implements OrderUseCase {
             .toList();
 
         return OrderMapper.toDetailOrderResponse(order, detailOrderProductResponses, locale);
-    }
-
-    private List<OrderResponse> getOrderResponse(final List<Order> orders) {
-        return orders.stream()
-            .map(
-                order -> OrderMapper.toOrderResponse(order, getOrderProductResponse(order), locale))
-            .toList();
-    }
-
-    private List<OrderProductResponse> getOrderProductResponse(final Order order) {
-        return order.getOrderProducts()
-            .stream()
-            .map(orderProduct -> OrderMapper.toOrderProductResponse(
-                getProductByProductId(orderProduct.getProductId())))
-            .toList();
     }
 
     private Product getProductByProductId(final long productId) {

--- a/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
@@ -35,16 +35,16 @@ public final class OrderMapper {
             .build();
     }
 
-    public static OrderProductResponse toOrderProductResponse(final Product product) {
-        return new OrderProductResponse(product.getId(), product.getName().getValue());
+    public static OrderProductResponse toOrderProductResponse(final Product product, final long quantity) {
+        return new OrderProductResponse(product.getId(), product.getName().getValue(),
+            product.getPrice().getValue().toString(), quantity);
     }
 
     public static OrderResponse toOrderResponse(final Order order,
         final List<OrderProductResponse> orderProductResponses, final String locale) {
 
         return new OrderResponse(order.getId(), orderProductResponses,
-            order.getTotalPrice().toString(), order.getOrderProducts().size(),
-            LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
+            order.getTotalPrice().toString(), LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
     }
 
     public static OrdersResponse toOrdersResponse(final List<OrderResponse> orderResponses,
@@ -60,7 +60,8 @@ public final class OrderMapper {
             LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
     }
 
-    public static DetailOrderProductResponse toDetailOrderProductResponse(final OrderProduct orderProduct, final Product product) {
+    public static DetailOrderProductResponse toDetailOrderProductResponse(final OrderProduct orderProduct,
+        final Product product) {
         return new DetailOrderProductResponse(orderProduct.getProductId(), product.getName().getValue(),
             product.getPrice().getValue().toString(), orderProduct.getQuantity());
     }

--- a/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
@@ -152,7 +152,7 @@ class OrderServiceTest {
                 Optional.of(product));
 
             final OrdersResponse expected = OrderDtoFixture.ordersResponse(List.of(defaultOrder), "Asia/Seoul",
-                page, size, product.getName().getValue());
+                page, size, product.getName().getValue(), product.getPrice().getValue().toString());
 
             // when
             final OrdersResponse result = orderUseCase.getOrderByUserId(userId, page, size);

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
@@ -17,30 +17,30 @@ public final class OrderDtoFixture {
     }
 
     public static OrdersResponse ordersResponse(final List<Order> orders, final String locale, final int page,
-        final int totalPage, final String fixedName) {
+        final int totalPage, final String fixedName, final String fixedPrice) {
 
-        final List<OrderResponse> orderResponses = getOrderResponse(orders, locale, fixedName);
+        final List<OrderResponse> orderResponses = getOrderResponse(orders, locale, fixedName, fixedPrice);
 
         return new OrdersResponse(orderResponses, page, totalPage);
     }
 
     private static List<OrderResponse> getOrderResponse(final List<Order> orders,
-        final String locale, final String fixedName) {
+        final String locale, final String fixedName, final String fixedPrice) {
 
         return orders.stream()
             .map(order -> new OrderResponse(order.getId(),
-                getOrderProductResponse(order, fixedName),
-                order.getTotalPrice().toString(), order.getOrderProducts().size(),
-                LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale))))
+                getOrderProductResponse(order, fixedName, fixedPrice),
+                order.getTotalPrice().toString(), LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale))))
             .toList();
     }
 
     private static List<OrderProductResponse> getOrderProductResponse(final Order order,
-        final String fixedName) {
+        final String fixedName, final String fixedPrice) {
 
         return order.getOrderProducts()
             .stream()
-            .map(orderProduct -> new OrderProductResponse(orderProduct.getProductId(), fixedName))
+            .map(orderProduct -> new OrderProductResponse(orderProduct.getProductId(), fixedName, fixedPrice,
+                orderProduct.getQuantity()))
             .toList();
     }
 


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
전체 상품 조회 API의 응답 body를 변경했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 변경전 json으로 구현되어 있는 부분을 다음 과 같이 변경했습니다

#### `As is`
``` json
{
     "orders" : [
               {
                        "orderId" : "number",
                        "products" :[ {
                                  "productId" : "number",
                                   "name" : "string"
                         }],
                        "price" : "number",
                        "quantity" : "number",
                        "createdAt":  "string",
               }
     ],
     "page" : "number",
     "totalPage" : "number"
}
```

#### `To be`
``` json
{
     "orders" : [
               {
                        "orderId" : "number",
                        "products" :[ {
                                  "productId" : "number",
                                   "name" : "string",
                                   "price": "number",
                                   "quantity": "number"	
                         }],
                        "totalPrice" : "number",
                        "createdAt":  "string",
               }
     ],
     "page" : "number",
     "totalPage" : "number"
}
```

## 🦀 이슈 넘버
- close #119 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
