### PR TITLE
test: 장바구니 상품 제거 기능 인수테스트 작성

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
@@ -5,6 +5,7 @@ import static shop.woowasap.accept.support.api.ShopApiSupporter.registerProduct;
 import static shop.woowasap.accept.support.fixture.CartFixture.cartResponse;
 import static shop.woowasap.accept.support.fixture.ProductFixture.registerProductRequest;
 import static shop.woowasap.accept.support.valid.CartValidator.assertCartProductsFound;
+import static shop.woowasap.accept.support.valid.HttpValidator.assertBadRequest;
 import static shop.woowasap.accept.support.valid.HttpValidator.assertOk;
 
 import io.restassured.response.ExtractableResponse;
@@ -111,4 +112,22 @@ class CartAcceptanceTest extends AcceptanceTest {
         assertOk(response);
     }
 
+    @Test
+    @DisplayName("ProductId에 해당하는 상품이 장바구니에 존재하지 않는다면, 400 BadRequest 를 응답한다.")
+    void returnBadRequestWhenCannotFoundProductInCart() {
+        // given
+        final String accessToken = "Token";
+        final long notExitProductId = 517;
+
+        final RegisterProductRequest registerProductRequest = registerProductRequest();
+        final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
+            registerProductRequest);
+
+        // when
+        final ExtractableResponse<Response> response = CartApiSupporter.deleteCartProduct(
+            accessToken, notExitProductId);
+
+        // then
+        assertBadRequest(response);
+    }
 }

--- a/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
@@ -5,6 +5,7 @@ import static shop.woowasap.accept.support.api.ShopApiSupporter.registerProduct;
 import static shop.woowasap.accept.support.fixture.CartFixture.cartResponse;
 import static shop.woowasap.accept.support.fixture.ProductFixture.registerProductRequest;
 import static shop.woowasap.accept.support.valid.CartValidator.assertCartProductsFound;
+import static shop.woowasap.accept.support.valid.HttpValidator.assertOk;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import shop.woowasap.accept.support.api.CartApiSupporter;
 import shop.woowasap.accept.support.fixture.CartFixture;
 import shop.woowasap.accept.support.fixture.ProductFixture;
-import shop.woowasap.accept.support.valid.HttpValidator;
 import shop.woowasap.shop.domain.api.cart.request.AddCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
 import shop.woowasap.shop.domain.api.product.request.RegisterProductRequest;
@@ -36,7 +36,7 @@ class CartAcceptanceTest extends AcceptanceTest {
             .addCartProduct(accessToken, CartFixture.addCartProductRequest(productId, quantity));
 
         // then
-        HttpValidator.assertOk(response);
+        assertOk(response);
     }
 
     @Test
@@ -58,7 +58,7 @@ class CartAcceptanceTest extends AcceptanceTest {
             .addCartProduct(accessToken, CartFixture.addCartProductRequest(productId, addQuantity));
 
         // then
-        HttpValidator.assertOk(response);
+        assertOk(response);
     }
 
     @Test
@@ -84,6 +84,31 @@ class CartAcceptanceTest extends AcceptanceTest {
 
         // then
         assertCartProductsFound(response, expected);
+    }
+
+
+    @Test
+    @DisplayName("장바구니에 있는 상품을 제거한다.")
+    void deleteCartProducts() {
+        // given
+        final String accessToken = "Token";
+        final long quantity = 10L;
+
+        final RegisterProductRequest registerProductRequest = registerProductRequest();
+        final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
+            registerProductRequest);
+        final long productId = Long.parseLong(registerResponse.header("Location").split("/")[4]);
+
+        final AddCartProductRequest addCartProductRequest = new AddCartProductRequest(productId,
+            quantity);
+        CartApiSupporter.addCartProduct(accessToken, addCartProductRequest);
+
+        // when
+        final ExtractableResponse<Response> response = CartApiSupporter.deleteCartProduct(
+            accessToken, productId);
+
+        // then
+        assertOk(response);
     }
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 장바구니에 들어있는 상품을 제거하는 인수테스트를 작성했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 상품 등록
- [x] 해당 상품을 장바구니에 추가
- [x] `DELETE /v1/carts?product-id={product-id}` 요청 시, 장바구니에서 해당 상품 제거 완료

## 🦀 이슈 넘버
- resolve #63 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
