### PR TITLE
feat: 장바구니의 상품 주문 서비스 추가

### DIFF
--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/DoesNotFindCartException.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/exception/DoesNotFindCartException.java
@@ -1,0 +1,10 @@
+package shop.woowasap.order.domain.exception;
+
+import java.text.MessageFormat;
+
+public final class DoesNotFindCartException extends RuntimeException {
+
+    public DoesNotFindCartException(final long cartId, final long userId) {
+        super(MessageFormat.format("cartId \"{0}\" 와 userId \"{1}\" 에 해당하는 Cart를 찾을 수 없습니다.", cartId, userId));
+    }
+}

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
@@ -8,6 +8,8 @@ public interface OrderUseCase {
 
     long orderProduct(final OrderProductRequest orderProductRequest);
 
+    long orderCartByCartIdAndUserId(final long cartId, final long userId);
+
     OrdersResponse getOrderByUserId(final long userId, final int page, final int size);
 
     DetailOrderResponse getOrderByOrderIdAndUserId(final long orderId, final long userId);

--- a/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
@@ -6,11 +6,13 @@ import java.util.List;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.OrderProduct;
+import shop.woowasap.order.domain.in.request.OrderProductRequest;
 import shop.woowasap.order.domain.in.response.DetailOrderProductResponse;
 import shop.woowasap.order.domain.in.response.DetailOrderResponse;
 import shop.woowasap.order.domain.in.response.OrderProductResponse;
 import shop.woowasap.order.domain.in.response.OrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
+import shop.woowasap.shop.domain.cart.Cart;
 import shop.woowasap.shop.domain.product.Product;
 
 public final class OrderMapper {
@@ -19,19 +21,35 @@ public final class OrderMapper {
         throw new UnsupportedOperationException("Cannot invoke constructor \"OrderMapper()\"");
     }
 
-    public static Order toDomain(final IdGenerator idGenerator, final long userId,
+    public static Order toDomain(final IdGenerator idGenerator, final OrderProductRequest orderProductRequest,
         final Product product) {
         return Order.builder()
             .id(idGenerator.generate())
+            .userId(orderProductRequest.userId())
+            .orderProducts(List.of(toOrderProduct(product, orderProductRequest.quantity())))
+            .build();
+    }
+
+    public static Order toDomain(final IdGenerator idGenerator, final long userId, final Cart cart) {
+        final List<OrderProduct> orderProducts = cart.getCartProducts()
+            .stream()
+            .map(cartProduct -> toOrderProduct(cartProduct.getProduct(), cartProduct.getQuantity().getValue()))
+            .toList();
+
+        return Order.builder()
+            .id(idGenerator.generate())
             .userId(userId)
-            .orderProducts(List.of(OrderProduct
-                .builder()
-                .productId(product.getId())
-                .price(product.getPrice().getValue().toString())
-                .quantity(product.getQuantity().getValue())
-                .startTime(product.getStartTime())
-                .endTime(product.getEndTime())
-                .build()))
+            .orderProducts(orderProducts)
+            .build();
+    }
+
+    private static OrderProduct toOrderProduct(final Product product, final long quantity) {
+        return OrderProduct.builder()
+            .productId(product.getId())
+            .price(product.getPrice().getValue().toString())
+            .quantity(quantity)
+            .startTime(product.getStartTime())
+            .endTime(product.getEndTime())
             .build();
     }
 

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/CartFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/CartFixture.java
@@ -1,0 +1,27 @@
+package shop.woowasap.order.service.support.fixture;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import shop.woowasap.shop.domain.cart.Cart;
+import shop.woowasap.shop.domain.cart.CartProduct;
+import shop.woowasap.shop.domain.cart.CartProductQuantity;
+import shop.woowasap.shop.domain.product.Product;
+
+public final class CartFixture {
+
+    private CartFixture() {
+    }
+
+    public static Cart.CartBuilder getEmptyCartBuilder() {
+        return Cart.builder()
+            .id(1L)
+            .userId(1L)
+            .cartProducts(new ArrayList<>());
+    }
+
+    public static CartProduct.CartProductBuilder getCartProductBuilder() {
+        return CartProduct.builder()
+            .product(ProductFixture.getDefaultBuilder().build())
+            .quantity(new CartProductQuantity(10L));
+    }
+}

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/api/cart/CartConnector.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/api/cart/CartConnector.java
@@ -1,0 +1,10 @@
+package shop.woowasap.shop.domain.api.cart;
+
+import java.util.Optional;
+import shop.woowasap.shop.domain.cart.Cart;
+
+public interface CartConnector {
+
+    Optional<Cart> findByCartIdAndUserId(final long cartId, final long userId);
+
+}

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartConnectorService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartConnectorService.java
@@ -1,0 +1,30 @@
+package shop.woowasap.shop.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.woowasap.shop.domain.api.cart.CartConnector;
+import shop.woowasap.shop.domain.cart.Cart;
+import shop.woowasap.shop.domain.spi.CartRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartConnectorService implements CartConnector {
+
+    private final CartRepository cartRepository;
+
+    @Override
+    public Optional<Cart> findByCartIdAndUserId(final long cartId, final long userId) {
+        try {
+            final Cart cart = cartRepository.getByUserId(userId);
+            if (!cart.getId().equals(cartId)) {
+                return Optional.empty();
+            }
+            return Optional.of(cart);
+        } catch (IllegalStateException illegalStateException) {
+            return Optional.empty();
+        }
+    }
+}

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/CartConnectorServiceTest.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/CartConnectorServiceTest.java
@@ -1,0 +1,95 @@
+package shop.woowasap.shop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import shop.woowasap.shop.domain.api.cart.CartConnector;
+import shop.woowasap.shop.domain.cart.Cart;
+import shop.woowasap.shop.domain.spi.CartRepository;
+import shop.woowasap.shop.service.support.fixture.CartFixture;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("CartConnectorService 클래스")
+@ContextConfiguration(classes = CartConnectorService.class)
+class CartConnectorServiceTest {
+
+    @Autowired
+    private CartConnector cartConnector;
+
+    @MockBean
+    private CartRepository cartRepository;
+
+    @Nested
+    @DisplayName("findByCartIdAndUserId 메소드는")
+    class findByCartIdAndUserIdMethod {
+
+        @Test
+        @DisplayName("cartId와 userId가 일치하는 Cart가 있다면 Cart를 반환한다.")
+        void returnCartWhenExistMatchedCart() {
+            // given
+            final long cartId = 1L;
+            final long userId = 2L;
+            final Cart expected = CartFixture.getEmptyCartBuilder()
+                .id(cartId)
+                .userId(userId)
+                .build();
+
+            when(cartRepository.getByUserId(userId)).thenReturn(expected);
+
+            // when
+            final Optional<Cart> result = cartConnector.findByCartIdAndUserId(cartId, userId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("cartId와 userId가 일치하는 Cart가 없다면, Optional.empty를 반환한다.")
+        void returnEmptyWhenCannotFindMatchedCart() {
+            // given
+            final long cartId = 1L;
+            final long userId = 2L;
+
+            when(cartRepository.getByUserId(userId)).thenThrow(new IllegalStateException());
+
+            // when
+            final Optional<Cart> result = cartConnector.findByCartIdAndUserId(cartId, userId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("조회된 cart의 cartId와 파라미터로 받은 cartId가 다르다면, Optional.empty를 반환한다.")
+        void returnEmptyWhenCartIdDoesNotMatch() {
+            // given
+            final long cartId = 1L;
+            final long userId = 2L;
+            final Cart cart = CartFixture.getEmptyCartBuilder()
+                .id(cartId)
+                .userId(userId)
+                .build();
+
+            when(cartRepository.getByUserId(userId)).thenReturn(cart);
+
+            final long invalidCartId = 999L;
+
+            // when
+            final Optional<Cart> result = cartConnector.findByCartIdAndUserId(invalidCartId, userId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
cartId와 userId로 장바구니 상품을 주문하는 서비스를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] shop.domain에 `CartConnector` 추가 (OrderService에서 사용)
- [x] shop.service에 `CartConnectorService` 추가
- [x] cartId와 userId를 받아, 주문을 진행하는 OrderUseCase 및 구현체 추가

## 🦀 이슈 넘버
- resolve #58 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
