### PR TITLE
feat: 장바구니 상품 제거 도메인

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/Cart.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/Cart.java
@@ -1,8 +1,11 @@
 package shop.woowasap.shop.domain.cart;
 
+import java.text.MessageFormat;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import shop.woowasap.shop.domain.exception.CannotFindProductInCartException;
+import shop.woowasap.shop.domain.product.Product;
 
 @Getter
 public final class Cart {
@@ -31,4 +34,20 @@ public final class Cart {
         cartProducts.remove(cartProduct);
         cartProducts.add(updatedCartProduct);
     }
+
+    public void deleteProduct(final Product product) {
+        validateProduct(product);
+        cartProducts.removeIf(cartProduct -> cartProduct.isSameProduct(product));
+    }
+
+    private void validateProduct(final Product product) {
+        if (cartProducts.stream().noneMatch(cartProduct -> cartProduct.isSameProduct(product))) {
+            throw new CannotFindProductInCartException(
+                MessageFormat.format(
+                    "product 가 장바구니에 존재하지 않습니다. productId : \"{0}\"",
+                    product.getId())
+            );
+        }
+    }
 }
+

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProduct.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProduct.java
@@ -24,4 +24,8 @@ public class CartProduct {
             .quantity(this.quantity.addQuantity(quantity))
             .build();
     }
+
+    public boolean isSameProduct(final Product product) {
+        return this.product.equals(product);
+    }
 }

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/exception/CannotFindProductInCartException.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/exception/CannotFindProductInCartException.java
@@ -1,0 +1,8 @@
+package shop.woowasap.shop.domain.exception;
+
+public class CannotFindProductInCartException extends CartException {
+
+    public CannotFindProductInCartException(final String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 장바구니에서 상품을 제거하는 도메인 메서드를 구현했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] product 를 Cart 에서 제거
- [x] product 가 Cart 에 존재하지 않는다면 예외 발생 

## 🦀 이슈 넘버
- resolve #63 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
