### PR TITLE
feat: `POST /v1/orders/carts/{cart-id}` 핸들러 추가

### DIFF
--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
+import shop.woowasap.order.domain.exception.DoesNotFindCartException;
 import shop.woowasap.order.domain.exception.DoesNotFindOrderException;
 import shop.woowasap.order.domain.exception.DoesNotFindProductException;
 import shop.woowasap.order.domain.exception.DoesNotOrderedException;
@@ -46,6 +47,14 @@ public class OrderController {
             .build();
     }
 
+    @PostMapping("/carts/{cart-id}")
+    public ResponseEntity<Void> orderCart(@PathVariable("cart-id") final long cartId) {
+        final long orderId = orderUseCase.orderCartByCartIdAndUserId(cartId, MOCK_USER_ID);
+
+        return ResponseEntity.created(URI.create("/v1/orders/" + orderId))
+            .build();
+    }
+
     @GetMapping
     public ResponseEntity<OrdersResponse> getOrdersByUserId(
         @RequestParam(defaultValue = "1") final int page,
@@ -67,7 +76,8 @@ public class OrderController {
         InvalidPriceException.class,
         InvalidProductSaleTimeException.class,
         InvalidQuantityException.class,
-        DoesNotFindOrderException.class})
+        DoesNotFindOrderException.class,
+        DoesNotFindCartException.class})
     private ResponseEntity<Void> handleBadRequest(final RuntimeException runtimeException) {
         return ResponseEntity.badRequest().build();
     }

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockCartRepository.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockCartRepository.java
@@ -1,5 +1,6 @@
 package shop.woowasap.shop.repository;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -26,8 +27,10 @@ public class MockCartRepository implements CartRepository {
 
     private static final String OFFSET_ID = "+09:00";
 
-    public static final LocalDateTime START_TIME = LocalDateTime.of(2023, 8, 5, 12, 30);
-    public static final LocalDateTime END_TIME = LocalDateTime.of(2023, 8, 5, 14, 30);
+    public static final LocalDateTime START_TIME = LocalDateTime.ofInstant(Instant.now().minusSeconds(100000),
+        ZoneOffset.UTC);
+    public static final LocalDateTime END_TIME = LocalDateTime.ofInstant(Instant.now().plusSeconds(100000),
+        ZoneOffset.UTC);
 
     @Override
     public Cart createEmptyCart(final Cart cart) {


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
`POST /v1/orders/carts/{cart-id}` 요청을 받아 처리하는 핸들러 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `POST /v1/orders/carts/{cart-id}` 핸들러 추가

## 🦀 이슈 넘버
- resolve #58 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
