### PR TITLE
test: 장바구니 상품 수량 수정 인수테스트 작성

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
@@ -5,6 +5,7 @@ import static shop.woowasap.accept.support.api.ShopApiSupporter.registerProduct;
 import static shop.woowasap.accept.support.fixture.CartFixture.cartResponse;
 import static shop.woowasap.accept.support.fixture.ProductFixture.registerProductRequest;
 import static shop.woowasap.accept.support.valid.CartValidator.assertCartProductsFound;
+import static shop.woowasap.accept.support.valid.HttpValidator.assertBadRequest;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -15,6 +16,7 @@ import shop.woowasap.accept.support.fixture.CartFixture;
 import shop.woowasap.accept.support.fixture.ProductFixture;
 import shop.woowasap.accept.support.valid.HttpValidator;
 import shop.woowasap.shop.domain.api.cart.request.AddCartProductRequest;
+import shop.woowasap.shop.domain.api.cart.request.UpdateCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
 import shop.woowasap.shop.domain.api.product.request.RegisterProductRequest;
 
@@ -84,6 +86,51 @@ class CartAcceptanceTest extends AcceptanceTest {
 
         // then
         assertCartProductsFound(response, expected);
+    }
+
+    @Test
+    @DisplayName("장바구니에 있는 상품의 수량을 수정한다.")
+    void updateCartProduct() {
+        // given
+        final String accessToken = "Token";
+        final long updatedQuantity = 10L;
+        final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
+            registerProductRequest());
+
+        final long productId = Long.parseLong(registerResponse.header("Location").split("/")[4]);
+        final UpdateCartProductRequest updateCartProductRequest = new UpdateCartProductRequest(
+            productId, updatedQuantity);
+
+        final AddCartProductRequest addCartProductRequest = new AddCartProductRequest(productId,
+            5L);
+        CartApiSupporter.addCartProduct(accessToken, addCartProductRequest);
+
+        final CartResponse expected = cartResponse(productId, updatedQuantity);
+
+        // when
+        CartApiSupporter.updateCartProduct(accessToken, updateCartProductRequest);
+
+        // then
+        final ExtractableResponse<Response> cartProducts = getCartProducts(accessToken);
+        assertCartProductsFound(cartProducts, expected);
+    }
+
+    @Test
+    @DisplayName("해당 장바구니에 담겨져 있지 않은 상품의 수량을 수정하는 경우 400 BadRequest를 반환한다.")
+    void updateNotExistsCartProduct() {
+        // given
+        final String accessToken = "Token";
+        final long invalidProductId = 999L;
+        final long quantity = 10L;
+        final UpdateCartProductRequest updateCartProductRequest = new UpdateCartProductRequest(
+            invalidProductId, quantity);
+
+        // when
+        final ExtractableResponse<Response> response = CartApiSupporter.updateCartProduct(
+            accessToken, updateCartProductRequest);
+
+        // then
+        assertBadRequest(response);
     }
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

장바구니 물건 수량 수정 인수테스트 작성했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] 장바구니 상품 수량 수정 인수테스트 작성
- [x] 장바구니에 해당 상품의 수량을 수정하려고 하면 400 BadRequest를 던지는 인수테스트 작성


## 🦀 이슈 넘버

- resolve #62 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
