### PR TITLE
feat: 장바구니 상품 제거 서비스 구현

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/spi/CartRepository.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/spi/CartRepository.java
@@ -4,8 +4,6 @@ import shop.woowasap.shop.domain.cart.Cart;
 
 public interface CartRepository {
 
-    Cart createEmptyCart(final Cart cart);
-
     Cart createEmptyCart(final long userId, final long cartId);
 
     Cart persist(final Cart cart);

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockCartRepository.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockCartRepository.java
@@ -30,11 +30,6 @@ public class MockCartRepository implements CartRepository {
     public static final LocalDateTime END_TIME = LocalDateTime.of(2023, 8, 5, 14, 30);
 
     @Override
-    public Cart createEmptyCart(final Cart cart) {
-        return null;
-    }
-
-    @Override
     public Cart createEmptyCart(final long userId, final long cartId) {
         return new Cart(MOCK_CART_ID, userId, new ArrayList<>());
     }

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
@@ -55,7 +55,15 @@ public class CartService implements CartUseCase {
 
     @Override
     public void deleteCartProduct(final long userId, final long productId) {
-        throw new UnsupportedOperationException();
+        if (!cartRepository.existCartByUserId(userId)) {
+            cartRepository.createEmptyCart(userId, idGenerator.generate());
+        }
+
+        final Cart cart = cartRepository.getByUserId(userId);
+        final Product product = getByProductId(productId);
+
+        cart.deleteProduct(product);
+        cartRepository.persist(cart);
     }
 
     @Override

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/CartServiceTest.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/CartServiceTest.java
@@ -220,6 +220,7 @@ class CartServiceTest {
                 Optional.of(product));
             when(cartRepository.createEmptyCart(eq(userId), anyLong())).thenReturn(emptyCart);
             when(cartRepository.getByUserId(userId)).thenReturn(emptyCart);
+
             // when
             final Exception exception = catchException(
                 () -> cartService.deleteCartProduct(userId, productId));


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 장바구니에 있는 상품을 제거하는 서비스를 구현했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 장바구니에 있는 상품 제거
- [x] productId 에 해당하는 상품이 존재하지 않을 경우, 예외 발생 
- [x] 장바구니가 존재하지 않을 경우, 빈 장바구니 생성
- [x] 장바구니에 삭제하려는 상품이 존재하지 않을 경우, 예외 발생

## 🦀 이슈 넘버
- resolve #63 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
