### PR TITLE
feat: 장바구니 상품 수량 수정 서비스 구현

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/api/cart/CartUseCase.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/api/cart/CartUseCase.java
@@ -1,12 +1,12 @@
 package shop.woowasap.shop.domain.api.cart;
 
 import shop.woowasap.shop.domain.api.cart.request.AddCartProductRequest;
+import shop.woowasap.shop.domain.api.cart.request.UpdateCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
-import shop.woowasap.shop.domain.api.product.request.UpdateProductRequest;
 
 public interface CartUseCase {
 
-    void updateCartProduct(final long userId, final UpdateProductRequest updateProductRequest);
+    void updateCartProduct(final long userId, final UpdateCartProductRequest updateCartProductRequest);
 
     void addCartProduct(final long userId, final AddCartProductRequest addCartProductRequest);
 

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/Cart.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/Cart.java
@@ -27,14 +27,12 @@ public final class Cart {
         cartProducts.add(cartProduct);
     }
 
-    public void updateCartProduct(final CartProduct cartProduct,
-        final CartProductQuantity quantity) {
+    public void updateCartProduct(final CartProduct cartProduct) {
         if (!cartProducts.contains(cartProduct)) {
             throw new NotExistsCartProductException("해당 상품이 장바구니에 존재하지 않습니다.");
         }
-        final CartProduct updatedCartProduct = cartProduct.updateQuantity(quantity);
         cartProducts.remove(cartProduct);
-        cartProducts.add(updatedCartProduct);
+        cartProducts.add(cartProduct);
     }
 
     private void updateCartProductInCartProducts(final CartProduct cartProduct) {

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProduct.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProduct.java
@@ -6,10 +6,13 @@ import lombok.Getter;
 import shop.woowasap.shop.domain.product.Product;
 
 @Getter
+@EqualsAndHashCode
 public class CartProduct {
 
     @EqualsAndHashCode.Include
     private final Product product;
+
+    @EqualsAndHashCode.Exclude
     private final CartProductQuantity quantity;
 
     @Builder

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartProductTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartProductTest.java
@@ -5,10 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchException;
 import static shop.woowasap.shop.domain.support.CartFixture.getCartProductBuilder;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import shop.woowasap.shop.domain.exception.InvalidCartProductQuantityException;
+import shop.woowasap.shop.domain.support.CartFixture;
 
 @DisplayName("CartProduct 테스트")
 class CartProductTest {

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartTest.java
@@ -75,13 +75,14 @@ class CartTest {
         @DisplayName("해당 상품이 없으면, 예외를 던진다.")
         void updateCartProductQuantityWithNotExistsCartProductThrowException() {
             // given
-            final CartProduct cartProduct = CartFixture.getCartProductBuilder().build();
             final CartProductQuantity updateCartProductQuantity = new CartProductQuantity(20L);
+            final CartProduct cartProduct = CartFixture.getCartProductBuilder()
+                .quantity(updateCartProductQuantity).build();
             final Cart cart = CartFixture.getEmptyCartBuilder().build();
 
             // when
             final Exception exception = catchException(
-                () -> cart.updateCartProduct(cartProduct, updateCartProductQuantity));
+                () -> cart.updateCartProduct(cartProduct));
 
             // then
             assertThat(exception).isInstanceOf(NotExistsCartProductException.class);
@@ -91,18 +92,20 @@ class CartTest {
         @DisplayName("정상적으로 개수가 변경된다.")
         void updateCartProductQuantityWithExists() {
             // given
-            final CartProduct cartProduct = CartFixture.getCartProductBuilder().build();
             final List<CartProduct> cartProducts = new ArrayList<>();
-            cartProducts.add(cartProduct);
+            cartProducts.add(CartFixture.getCartProductBuilder().build());
             final CartProductQuantity updateCartProductQuantity = new CartProductQuantity(20L);
+            final CartProduct updateCartProduct = CartFixture.getCartProductBuilder()
+                .quantity(updateCartProductQuantity).build();
             final Cart cart = CartFixture.getEmptyCartBuilder().cartProducts(cartProducts).build();
 
             // when
-            cart.updateCartProduct(cartProduct, updateCartProductQuantity);
+            cart.updateCartProduct(updateCartProduct);
 
             // then
             assertThat(cart.getCartProducts()).hasSize(1);
-            assertThat(cart.getCartProducts().get(0).getQuantity()).isEqualTo(updateCartProductQuantity);
+            assertThat(cart.getCartProducts().get(0).getQuantity()).isEqualTo(
+                updateCartProductQuantity);
         }
     }
 }

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
@@ -9,8 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.shop.domain.api.cart.CartUseCase;
 import shop.woowasap.shop.domain.api.cart.request.AddCartProductRequest;
+import shop.woowasap.shop.domain.api.cart.request.UpdateCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
-import shop.woowasap.shop.domain.api.product.request.UpdateProductRequest;
 import shop.woowasap.shop.domain.cart.Cart;
 import shop.woowasap.shop.domain.cart.CartProduct;
 import shop.woowasap.shop.domain.cart.CartProductQuantity;
@@ -31,8 +31,19 @@ public class CartService implements CartUseCase {
     @Override
     @Transactional
     public void updateCartProduct(final long userId,
-        final UpdateProductRequest updateProductRequest) {
-        throw new UnsupportedOperationException();
+        final UpdateCartProductRequest updateCartProductRequest) {
+        if (!cartRepository.existCartByUserId(userId)) {
+            cartRepository.createEmptyCart(userId, idGenerator.generate());
+        }
+
+        final Cart cart = cartRepository.getByUserId(userId);
+        final Product product = getByProductId(updateCartProductRequest.productId());
+
+        cart.updateCartProduct(CartProduct.builder()
+            .product(product)
+            .quantity(new CartProductQuantity(updateCartProductRequest.quantity()))
+            .build());
+        cartRepository.persist(cart);
     }
 
     @Override

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/support/fixture/CartFixture.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/support/fixture/CartFixture.java
@@ -3,6 +3,7 @@ package shop.woowasap.shop.service.support.fixture;
 import static shop.woowasap.shop.service.support.fixture.ProductFixture.productBuilder;
 
 import java.util.List;
+import shop.woowasap.shop.domain.api.cart.request.UpdateCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartProductResponse;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
 import java.util.ArrayList;
@@ -46,6 +47,10 @@ public final class CartFixture {
 
     public static AddCartProductRequest addCartProductRequest(final Long productId, final Long quantity) {
         return new AddCartProductRequest(productId, quantity);
+    }
+
+    public static UpdateCartProductRequest updateCartProductRequest(final Long productId, final Long quantity) {
+        return new UpdateCartProductRequest(productId, quantity);
     }
 
     public static CartProduct cartProduct() {


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

장바구니 상품 수량 수정 서비스를 구현했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] Cart, CartProduct 상품 수량 도메인 로직 수정
- [x] CartService 상품 수량 수정 메서드 구현 
- [x] CartServiceTest 상품 수량 수정 테스트 작성

## 🦀 이슈 넘버

- resolve #62 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
