### PR TITLE
feat: 장바구니 상품 제거 컨트롤러 구현

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
@@ -93,16 +93,8 @@ class CartAcceptanceTest extends AcceptanceTest {
     void deleteCartProducts() {
         // given
         final String accessToken = "Token";
-        final long quantity = 10L;
 
-        final RegisterProductRequest registerProductRequest = registerProductRequest();
-        final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
-            registerProductRequest);
-        final long productId = Long.parseLong(registerResponse.header("Location").split("/")[4]);
-
-        final AddCartProductRequest addCartProductRequest = new AddCartProductRequest(productId,
-            quantity);
-        CartApiSupporter.addCartProduct(accessToken, addCartProductRequest);
+        final long productId = 33L;
 
         // when
         final ExtractableResponse<Response> response = CartApiSupporter.deleteCartProduct(
@@ -118,10 +110,6 @@ class CartAcceptanceTest extends AcceptanceTest {
         // given
         final String accessToken = "Token";
         final long notExitProductId = 517;
-
-        final RegisterProductRequest registerProductRequest = registerProductRequest();
-        final ExtractableResponse<Response> registerResponse = registerProduct(accessToken,
-            registerProductRequest);
 
         // when
         final ExtractableResponse<Response> response = CartApiSupporter.deleteCartProduct(

--- a/app/src/test/java/shop/woowasap/accept/support/api/CartApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/CartApiSupporter.java
@@ -59,7 +59,7 @@ public final class CartApiSupporter {
         return given().log().all()
             .accept(JSON)
             .header(HttpHeaders.AUTHORIZATION, token)
-            .queryParam("productId", productId)
+            .queryParam("product-id", productId)
             .when().log().all()
             .delete(API_VERSION + "/carts")
             .then().log().all()

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
@@ -2,14 +2,18 @@ package shop.woowasap.shop.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.shop.domain.api.cart.CartUseCase;
 import shop.woowasap.shop.domain.api.cart.request.AddCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
+import shop.woowasap.shop.domain.exception.CannotFindProductInCartException;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,4 +37,15 @@ public class CartController {
         return ResponseEntity.ok().build();
     }
 
+    @DeleteMapping
+    public ResponseEntity<Void> deleteCartProduct(@RequestParam("product-id") long productId) {
+        cartUseCase.deleteCartProduct(MOCK_USER_ID, productId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @ExceptionHandler(CannotFindProductInCartException.class)
+    public ResponseEntity<Void> handleException() {
+        return ResponseEntity.badRequest().build();
+    }
 }

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
@@ -38,7 +38,8 @@ public class CartController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteCartProduct(@RequestParam("product-id") long productId) {
+    public ResponseEntity<Void> deleteCartProduct(
+        @RequestParam("product-id") final long productId) {
         cartUseCase.deleteCartProduct(MOCK_USER_ID, productId);
 
         return ResponseEntity.ok().build();

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/api/cart/CartUseCase.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/api/cart/CartUseCase.java
@@ -1,12 +1,12 @@
 package shop.woowasap.shop.domain.api.cart;
 
 import shop.woowasap.shop.domain.api.cart.request.AddCartProductRequest;
+import shop.woowasap.shop.domain.api.cart.request.UpdateCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
-import shop.woowasap.shop.domain.api.product.request.UpdateProductRequest;
 
 public interface CartUseCase {
 
-    void updateCartProduct(final long userId, final UpdateProductRequest updateProductRequest);
+    void updateCartProduct(final long userId, final UpdateCartProductRequest updateProductRequest);
 
     void addCartProduct(final long userId, final AddCartProductRequest addCartProductRequest);
 

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockCartRepository.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockCartRepository.java
@@ -22,7 +22,7 @@ public class MockCartRepository implements CartRepository {
     public static final long ORDER_QUANTITY = 10L;
 
     public static final long MOCK_CART_ID = 1L;
-    public static final long MOCK_PRODUCT_ID = 1L;
+    public static final long MOCK_PRODUCT_ID = 33L;
 
     private static final String OFFSET_ID = "+09:00";
 

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockProductRepository.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/MockProductRepository.java
@@ -18,10 +18,17 @@ public class MockProductRepository implements ProductRepository {
     public static final String DESCRIPTION = "productDescription";
     public static final String PRICE = "10000";
     public static final long QUANTITY = 10L;
-    public static final LocalDateTime START_TIME = LocalDateTime.ofInstant(Instant.now().minusSeconds(100000), ZoneOffset.UTC);
-    public static final LocalDateTime END_TIME = LocalDateTime.ofInstant(Instant.now().plusSeconds(100000), ZoneOffset.UTC);
+    public static final LocalDateTime START_TIME = LocalDateTime.ofInstant(
+        Instant.now().minusSeconds(100000), ZoneOffset.UTC);
+    public static final LocalDateTime END_TIME = LocalDateTime.ofInstant(
+        Instant.now().plusSeconds(100000), ZoneOffset.UTC);
+
+    public static final LocalDateTime STATIC_START_TIME = LocalDateTime.of(2023, 8, 5, 12, 30);
+    public static final LocalDateTime STATIC_END_TIME = LocalDateTime.of(2023, 8, 5, 14, 30);
+
     public static final LocalDateTime INFINITE_START_TIME = LocalDateTime.of(2030, 12, 1, 23, 59);
     public static final LocalDateTime INFINITE_END_TIME = LocalDateTime.of(2030, 12, 31, 23, 59);
+
     private static final String OFFSET_ID = "+09:00";
 
     @Override
@@ -34,6 +41,18 @@ public class MockProductRepository implements ProductRepository {
         if (productId == 123L) {
             return Optional.empty();
         }
+
+        if (productId == 33L) {
+            return Optional.of(Product.builder()
+                .id(productId)
+                .name(NAME)
+                .description(DESCRIPTION)
+                .price(PRICE)
+                .quantity(QUANTITY)
+                .startTime(STATIC_START_TIME.toInstant(ZoneOffset.of(OFFSET_ID)))
+                .endTime(STATIC_END_TIME.toInstant(ZoneOffset.of(OFFSET_ID))).build());
+        }
+
         return Optional.of(Product.builder()
             .id(productId)
             .name(NAME)
@@ -70,7 +89,8 @@ public class MockProductRepository implements ProductRepository {
             .startTime(INFINITE_START_TIME.toInstant(ZoneOffset.of(OFFSET_ID)))
             .endTime(INFINITE_END_TIME.toInstant(ZoneOffset.of(OFFSET_ID)));
 
-        List<Product> products = List.of(productBuilder.id(1L).build(), productBuilder.id(2L).build());
+        List<Product> products = List.of(productBuilder.id(1L).build(),
+            productBuilder.id(2L).build());
         return new ProductsPaginationResponse(products, 1, 1);
     }
 

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
@@ -9,8 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.shop.domain.api.cart.CartUseCase;
 import shop.woowasap.shop.domain.api.cart.request.AddCartProductRequest;
+import shop.woowasap.shop.domain.api.cart.request.UpdateCartProductRequest;
 import shop.woowasap.shop.domain.api.cart.response.CartResponse;
-import shop.woowasap.shop.domain.api.product.request.UpdateProductRequest;
 import shop.woowasap.shop.domain.cart.Cart;
 import shop.woowasap.shop.domain.cart.CartProduct;
 import shop.woowasap.shop.domain.cart.CartProductQuantity;
@@ -31,7 +31,7 @@ public class CartService implements CartUseCase {
     @Override
     @Transactional
     public void updateCartProduct(final long userId,
-        final UpdateProductRequest updateProductRequest) {
+        final UpdateCartProductRequest updateCartProductRequest) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 장바구니 상품 제거 컨트롤러를 구현했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `DELETE /v1/carts/product-id={product-id}` 에 매핑되는 컨트롤러 구현

## 🦀 이슈 넘버
- resolve #63 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
