### PR TITLE
feat: 인수테스트용 어드민 계정 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/AcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/AcceptanceTest.java
@@ -5,11 +5,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import shop.woowasap.BeanScanBaseLocation;
 
+@Import(AcceptanceTestConfiguration.class)
 @ContextConfiguration(classes = BeanScanBaseLocation.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)

--- a/app/src/test/java/shop/woowasap/accept/AcceptanceTestConfiguration.java
+++ b/app/src/test/java/shop/woowasap/accept/AcceptanceTestConfiguration.java
@@ -22,10 +22,10 @@ public class AcceptanceTestConfiguration {
     }
 
     @Bean
-    public ApplicationRunner dataInitializer(UserRepository userRepository,
-        PasswordEncoder passwordEncoder) {
+    public ApplicationRunner dataInitializer(final UserRepository userRepository,
+        final PasswordEncoder passwordEncoder) {
         return args -> {
-            User admin = User.builder()
+            final User admin = User.builder()
                 .id(12345L)
                 .username("admin")
                 .password(passwordEncoder.encode("1234567890"))

--- a/app/src/test/java/shop/woowasap/accept/AcceptanceTestConfiguration.java
+++ b/app/src/test/java/shop/woowasap/accept/AcceptanceTestConfiguration.java
@@ -1,0 +1,37 @@
+package shop.woowasap.accept;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import shop.woowasap.auth.domain.User;
+import shop.woowasap.auth.domain.UserType;
+import shop.woowasap.auth.domain.out.UserRepository;
+
+@TestConfiguration
+public class AcceptanceTestConfiguration {
+
+    @Bean
+    @Primary
+    public Clock fixedClock() {
+        return Clock.fixed(Instant.parse("2023-08-15T00:00:02.00Z"), ZoneId.of("Asia/Seoul"));
+    }
+
+    @Bean
+    public ApplicationRunner dataInitializer(UserRepository userRepository,
+        PasswordEncoder passwordEncoder) {
+        return args -> {
+            User admin = User.builder()
+                .id(12345L)
+                .username("admin")
+                .password(passwordEncoder.encode("1234567890"))
+                .userType(UserType.ROLE_ADMIN)
+                .build();
+            userRepository.insertUser(admin);
+        };
+    }
+}

--- a/app/src/test/java/shop/woowasap/accept/support/api/AuthApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/AuthApiSupporter.java
@@ -7,6 +7,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import shop.woowasap.auth.controller.request.LoginRequest;
 import shop.woowasap.auth.controller.request.SignUpRequest;
+import shop.woowasap.auth.domain.in.response.LoginResponse;
 
 public final class AuthApiSupporter {
 
@@ -37,4 +38,16 @@ public final class AuthApiSupporter {
             .extract();
     }
 
+    public static String adminAccessToken() {
+        return given()
+            .contentType(JSON)
+            .accept(JSON)
+            .body(new LoginRequest("admin", "1234567890"))
+            .when()
+            .post(API_VERSION + "/login")
+            .then()
+            .extract()
+            .as(LoginResponse.class)
+            .accessToken();
+    }
 }

--- a/auth/auth-repository/src/main/java/shop/woowasap/auth/repository/entity/UserEntity.java
+++ b/auth/auth-repository/src/main/java/shop/woowasap/auth/repository/entity/UserEntity.java
@@ -27,7 +27,7 @@ public class UserEntity extends BaseEntity {
     private String password;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "user_type", nullable = false)
+    @Column(name = "user_type", length = 16, nullable = false)
     private UserEntityType userType;
 
     @Builder


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
인수테스트용 어드민 계정 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 테스트용 설정 `AcceptanceTestConfiguration` 추가
- [x] 테스트용 fixedClock 추가 
- [x] 테스트용 어드민 계정 추가 
- [x] `AuthApiSupporter.adminAccessToken()` 추가

## 🦀 이슈 넘버
- resolve #150 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
