### PR TITLE
chore: sonarcloud 가 develop에 push됐을때도 수행되도록 수정

### DIFF
--- a/.github/workflows/acceptancetest-analyze.yml
+++ b/.github/workflows/acceptancetest-analyze.yml
@@ -3,7 +3,9 @@ on:
   pull_request:
     branches:
       - 'develop'
-      - 'main' # TODO : Sonarcloud 테스트용 나중에 지우기
+  push:
+    branches:
+      - 'develop'
 
 jobs:
   build:


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
sonarcloud 가 develop에 push됐을때도 수행되도록 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `.github/workflows/acceptancetest-analyze.yml` 에 push절 추가
- [x] `.github/workflows/acceptancetest-analyze.yml` 에 디버깅용 절 삭제

## 🦀 이슈 넘버
- close #173 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
