### PR TITLE
feat: 주문 성공시 상품 재고 감소 기능 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -197,9 +197,10 @@ class OrderAcceptanceTest extends AcceptanceTest {
         final long expectedQuantity = 0L;
 
         // when
-        final ExtractableResponse<Response> result = ShopApiSupporter.getProduct(productId);
+        OrderApiSupporter.orderProduct(productId, orderProductRequest, accessToken);
 
         // then
+        final ExtractableResponse<Response> result = ShopApiSupporter.getProduct(productId);
         assertThat(result.as(ProductDetailsResponse.class).quantity()).isEqualTo(expectedQuantity);
     }
 

--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -192,8 +192,6 @@ class OrderAcceptanceTest extends AcceptanceTest {
         final OrderProductQuantityRequest orderProductRequest = new OrderProductQuantityRequest(
             quantity);
 
-        OrderApiSupporter.orderProduct(productId, orderProductRequest, accessToken);
-
         final long expectedQuantity = 0L;
 
         // when

--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -1,5 +1,7 @@
 package shop.woowasap.accept;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.math.BigInteger;
@@ -23,6 +25,7 @@ import shop.woowasap.order.domain.in.response.OrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.shop.domain.in.cart.request.AddCartProductRequest;
 import shop.woowasap.shop.domain.in.cart.response.CartResponse;
+import shop.woowasap.shop.domain.in.product.response.ProductDetailsResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductsResponse;
 
@@ -148,7 +151,6 @@ class OrderAcceptanceTest extends AcceptanceTest {
     @DisplayName("장바구니 상품 구매 API는 장바구니의 상품을 구매한 후, Created와 Location을 응답한다.")
     void returnCreatedAndLocationWhenSuccessToBuyCart() {
         // given
-
         final ProductResponse product = getRandomProduct(accessToken);
         final int quantity = 2;
         final AddCartProductRequest addCartProductRequest = new AddCartProductRequest(
@@ -179,6 +181,26 @@ class OrderAcceptanceTest extends AcceptanceTest {
 
         // then
         HttpValidator.assertBadRequest(result);
+    }
+
+    @Test
+    @DisplayName("상품 구매에 성공한 경우, product quantity가 줄어든다.")
+    void consumeProductQuantityWhenProductOrdered() {
+        // given
+        final long productId = getRandomProduct(accessToken).productId();
+        final int quantity = 10;
+        final OrderProductQuantityRequest orderProductRequest = new OrderProductQuantityRequest(
+            quantity);
+
+        OrderApiSupporter.orderProduct(productId, orderProductRequest, accessToken);
+
+        final long expectedQuantity = 0L;
+
+        // when
+        final ExtractableResponse<Response> result = ShopApiSupporter.getProduct(productId);
+
+        // then
+        assertThat(result.as(ProductDetailsResponse.class).quantity()).isEqualTo(expectedQuantity);
     }
 
     private ProductResponse getRandomProduct(final String accessToken) {

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -53,7 +53,7 @@ public class OrderService implements OrderUseCase {
         }
 
         orderRepository.persist(order);
-        productConnector.consumeProductByProductId(product.getId(), 1);
+        productConnector.consumeProductByProductId(product.getId(), orderProductRequest.quantity());
         return order.getId();
     }
 

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -47,11 +47,13 @@ public class OrderService implements OrderUseCase {
         final Product product = getProductByProductId(orderProductRequest.productId());
         final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest, product);
 
-        if (!payment.pay(orderProductRequest.userId(), order.getId(), order.getTotalPrice().toString())) {
+        if (!payment.pay(orderProductRequest.userId(), order.getId(),
+            order.getTotalPrice().toString())) {
             throw new DoesNotOrderedException();
         }
 
         orderRepository.persist(order);
+        productConnector.consumeProductByProductId(product.getId(), 1);
         return order.getId();
     }
 
@@ -73,6 +75,9 @@ public class OrderService implements OrderUseCase {
         }
 
         orderRepository.persist(order);
+        cart.getCartProducts()
+            .forEach(cartProduct -> productConnector.consumeProductByProductId(
+                cartProduct.getProduct().getId(), cartProduct.getQuantity().getValue()));
         return order.getId();
     }
 
@@ -83,7 +88,8 @@ public class OrderService implements OrderUseCase {
         final List<Order> orders = ordersPaginationResponse.orders();
 
         final List<OrderResponse> orderResponses = orders.stream()
-            .map(order -> OrderMapper.toOrderResponse(order, getOrderProductResponse(order), locale))
+            .map(
+                order -> OrderMapper.toOrderResponse(order, getOrderProductResponse(order), locale))
             .toList();
 
         return OrderMapper.toOrdersResponse(orderResponses, ordersPaginationResponse.page(),

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/in/product/ProductConnector.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/in/product/ProductConnector.java
@@ -7,4 +7,5 @@ public interface ProductConnector {
 
     Optional<Product> findByProductId(final long productId);
 
+    void consumeProductByProductId(final long productId, final long quantity);
 }

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/out/ProductRepository.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/out/ProductRepository.java
@@ -15,4 +15,6 @@ public interface ProductRepository {
     ProductsPaginationResponse findAllValidWithPagination(final int page, final int size);
 
     ProductsPaginationResponse findAllWithPagination(final int page, final int size);
+
+    void consumeQuantityByProductId(final long productId, final long consumedQuantity);
 }

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/ProductRepositoryImpl.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/ProductRepositoryImpl.java
@@ -61,4 +61,9 @@ public class ProductRepositoryImpl implements ProductRepository {
 
         return new ProductsPaginationResponse(products, page, pagination.getTotalPages());
     }
+
+    @Override
+    public void consumeQuantityByProductId(long productId, long consumedQuantity) {
+        productJpaRepository.consumeQuantity(productId, consumedQuantity);
+    }
 }

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/jpa/ProductJpaRepository.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/jpa/ProductJpaRepository.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import shop.woowasap.shop.repository.entity.ProductEntity;
 
 public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long> {
@@ -15,4 +18,9 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
     Page<ProductEntity> findAllByEndTimeAfter(final Instant nowTime, final Pageable pageable);
 
     Page<ProductEntity> findAll(final Pageable pageable);
+
+    @Modifying
+    @Query("update ProductEntity as p set p.quantity = p.quantity - :consumedQuantity where p.id = :productId")
+    void consumeQuantity(@Param("productId") final long productId,
+        @Param("consumedQuantity") final long consumedQuantity);
 }

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/jpa/ProductJpaRepository.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/jpa/ProductJpaRepository.java
@@ -19,7 +19,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
 
     Page<ProductEntity> findAll(final Pageable pageable);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("update ProductEntity as p set p.quantity = p.quantity - :consumedQuantity where p.id = :productId")
     void consumeQuantity(@Param("productId") final long productId,
         @Param("consumedQuantity") final long consumedQuantity);

--- a/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
+++ b/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
@@ -25,9 +25,6 @@ class ProductRepositoryImplTest {
     @Autowired
     private ProductRepositoryImpl productRepository;
 
-    @Autowired
-    EntityManager entityManager;
-
     @Nested
     @DisplayName("persist 메서드는")
     class PersistMethod {
@@ -245,9 +242,6 @@ class ProductRepositoryImplTest {
             // when
             productRepository.consumeQuantityByProductId(persistProduct.getId(),
                 persistProduct.getQuantity().getValue());
-
-            entityManager.flush();
-            entityManager.clear();
 
             // then
             final Optional<Product> result = productRepository.findById(persistProduct.getId());

--- a/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
+++ b/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
@@ -29,7 +29,7 @@ class ProductRepositoryImplTest {
     EntityManager entityManager;
 
     @Nested
-    @DisplayName("persis 메서드는")
+    @DisplayName("persist 메서드는")
     class PersistMethod {
 
         @Test
@@ -224,6 +224,35 @@ class ProductRepositoryImplTest {
 
             // then
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("consumeQuantityByProductId 메서드는")
+    class consumeQuantityByProductIdMethod {
+
+        @Test
+        @DisplayName("product의 quantity를 줄인다.")
+        void consumeProductQuantity() {
+            // given
+            final long productId = 1L;
+            final long quantity = 10L;
+            final Product persistProduct =
+                productRepository.persist(ProductFixture.salePriorProduct(productId, quantity));
+
+            final long expectedQuantity = 0;
+
+            // when
+            productRepository.consumeQuantityByProductId(persistProduct.getId(),
+                persistProduct.getQuantity().getValue());
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            final Optional<Product> result = productRepository.findById(persistProduct.getId());
+            assertThat(result).isPresent();
+            assertThat(result.get().getQuantity().getValue()).isEqualTo(expectedQuantity);
         }
     }
 }

--- a/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/support/ProductFixture.java
+++ b/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/support/ProductFixture.java
@@ -55,4 +55,16 @@ public class ProductFixture {
             .endTime(SALE_PRIOR_END_TIME.toInstant(ZoneOffset.UTC))
             .build();
     }
+
+    public static Product salePriorProduct(final Long id, final Long quantity) {
+        return Product.builder()
+            .id(id)
+            .name(NAME)
+            .description(DESCRIPTION)
+            .price(PRICE)
+            .quantity(quantity)
+            .startTime(SALE_PRIOR_START_TIME.toInstant(ZoneOffset.UTC))
+            .endTime(SALE_PRIOR_END_TIME.toInstant(ZoneOffset.UTC))
+            .build();
+    }
 }

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductConnectorService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductConnectorService.java
@@ -1,13 +1,9 @@
 package shop.woowasap.shop.service;
 
-import java.text.MessageFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import shop.woowasap.shop.domain.exception.NotExistsProductException;
 import shop.woowasap.shop.domain.in.product.ProductConnector;
 import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.ProductRepository;
@@ -27,25 +23,6 @@ public class ProductConnectorService implements ProductConnector {
     @Override
     @Transactional
     public void consumeProductByProductId(final long productId, final long consumedQuantity) {
-        Product product = getProduct(productId);
-
-        product = product.update(
-            product.getName().getValue(),
-            product.getDescription().getValue(),
-            product.getPrice().getValue().toString(),
-            product.getQuantity().getValue() - consumedQuantity,
-            LocalDateTime.ofInstant(product.getStartTime(), ZoneId.of("UTC")),
-            LocalDateTime.ofInstant(product.getEndTime(), ZoneId.of("UTC"))
-        );
-
-        productRepository.persist(product);
-    }
-
-    private Product getProduct(final long productId) {
-        return productRepository.findById(productId)
-            .orElseThrow(() -> new NotExistsProductException(
-                MessageFormat.format("productId 에 해당하는 Product 가 존재하지 않습니다. productId \"{0}\"",
-                    productId)
-            ));
+        productRepository.consumeQuantityByProductId(productId, consumedQuantity);
     }
 }

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductConnectorService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductConnectorService.java
@@ -1,9 +1,13 @@
 package shop.woowasap.shop.service;
 
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shop.woowasap.shop.domain.exception.NotExistsProductException;
 import shop.woowasap.shop.domain.in.product.ProductConnector;
 import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.ProductRepository;
@@ -18,5 +22,30 @@ public class ProductConnectorService implements ProductConnector {
     @Override
     public Optional<Product> findByProductId(final long productId) {
         return productRepository.findById(productId);
+    }
+
+    @Override
+    @Transactional
+    public void consumeProductByProductId(final long productId, final long consumedQuantity) {
+        Product product = getProduct(productId);
+
+        product = product.update(
+            product.getName().getValue(),
+            product.getDescription().getValue(),
+            product.getPrice().getValue().toString(),
+            product.getQuantity().getValue() - consumedQuantity,
+            LocalDateTime.ofInstant(product.getStartTime(), ZoneId.of("UTC")),
+            LocalDateTime.ofInstant(product.getEndTime(), ZoneId.of("UTC"))
+        );
+
+        productRepository.persist(product);
+    }
+
+    private Product getProduct(final long productId) {
+        return productRepository.findById(productId)
+            .orElseThrow(() -> new NotExistsProductException(
+                MessageFormat.format("productId 에 해당하는 Product 가 존재하지 않습니다. productId \"{0}\"",
+                    productId)
+            ));
     }
 }

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductConnectorServiceTest.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductConnectorServiceTest.java
@@ -13,8 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import shop.woowasap.shop.domain.exception.InvalidProductQuantityException;
-import shop.woowasap.shop.domain.exception.NotExistsProductException;
 import shop.woowasap.shop.domain.in.product.ProductConnector;
 import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.ProductRepository;
@@ -94,44 +92,6 @@ class ProductConnectorServiceTest {
 
             // then
             assertThat(result).isNull();
-        }
-
-        @Test
-        @DisplayName("product의 quantity가 consumedQuantity 보다 작다면, InvalidProductQuantityException를 던진다.")
-        void throwInvalidProductQuantityExceptionWhenQuantityLessThenConsumedQuantity() {
-            // given
-            final long productId = 1L;
-            final long consumedQuantity = 10L;
-
-            final Product persistedProduct = ProductFixture.productBuilder(productId)
-                .quantity(consumedQuantity - 1)
-                .build();
-
-            when(productRepository.findById(productId)).thenReturn(Optional.of(persistedProduct));
-
-            // when
-            final Exception result = catchException(
-                () -> productConnector.consumeProductByProductId(productId, consumedQuantity));
-
-            // then
-            assertThat(result).isInstanceOf(InvalidProductQuantityException.class);
-        }
-
-        @Test
-        @DisplayName("productId에 해당하는 product를 찾을 수 없으면, NotExistsProductException를 던진다.")
-        void throwNotExistsProductExceptionWhenProductNotExist() {
-            // given
-            final long productId = 1L;
-            final long consumedQuantity = 1L;
-
-            when(productRepository.findById(productId)).thenReturn(Optional.empty());
-
-            // when
-            final Exception result = catchException(
-                () -> productConnector.consumeProductByProductId(productId, consumedQuantity));
-
-            // then
-            assertThat(result).isInstanceOf(NotExistsProductException.class);
         }
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
상품, 카트 구매에 성공하면, 상품 수량이 줄어드는 기능을 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `ProductConnector` 에 상품 수량을 줄이는 메소드 추가
- [x] `OrderService` 에서 `결제 성공` 하고 `주문 생성` 이 되었다면, 상품 수량을 감소시키는 로직 추가
- [x] 관련 인수테스트와 통합테스트 추가
 
## 🦀 이슈 넘버
- #182 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
