### PR TITLE
refactor: 주문성공시 OrderIdResponse와 Ok를 반환하도록 수정

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -40,8 +40,8 @@ class OrderAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("상품 바로 구매 API는 productId와 quantity를 받아 상품을 구매한후, Created와 Location을 응답한다.")
-    void returnCreatedAndLocationWhenSuccessToBuyProduct() {
+    @DisplayName("상품 바로 구매 API는 productId와 quantity를 받아 상품을 구매한후, Ok와 OrderIdResponse를 응답한다.")
+    void returnOkAndOrderIdResponseWhenSuccessToBuyProduct() {
         // given
         final long productId = getRandomProduct(accessToken).productId();
         final int quantity = 2;
@@ -148,8 +148,8 @@ class OrderAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("장바구니 상품 구매 API는 장바구니의 상품을 구매한 후, Created와 Location을 응답한다.")
-    void returnCreatedAndLocationWhenSuccessToBuyCart() {
+    @DisplayName("장바구니 상품 구매 API는 장바구니의 상품을 구매한 후, Ok와 OrderIdResponse를 응답한다.")
+    void returnOkAndOrderIdResponseWhenSuccessToBuyCart() {
         // given
         final ProductResponse product = getRandomProduct(accessToken);
         final int quantity = 2;

--- a/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
+++ b/app/src/test/java/shop/woowasap/accept/support/valid/OrderValidator.java
@@ -6,6 +6,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
 import shop.woowasap.order.domain.in.response.DetailOrderResponse;
+import shop.woowasap.order.domain.in.response.OrderIdResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 
 public final class OrderValidator {
@@ -15,9 +16,11 @@ public final class OrderValidator {
     }
 
     public static void assertOrdered(ExtractableResponse<Response> result) {
-        HttpValidator.assertCreated(result);
+        HttpValidator.assertOk(result);
 
-        assertThat(result.header(HttpHeaders.LOCATION)).contains("/v1/orders/");
+        OrderIdResponse resultResponse = result.as(OrderIdResponse.class);
+
+        assertThat(resultResponse.orderId()).isPositive();
     }
 
     public static void assertOrders(ExtractableResponse<Response> result, OrdersResponse expected) {

--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -1,6 +1,5 @@
 package shop.woowasap.order.controller;
 
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -24,6 +23,7 @@ import shop.woowasap.order.domain.exception.InvalidQuantityException;
 import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
 import shop.woowasap.order.domain.in.response.DetailOrderResponse;
+import shop.woowasap.order.domain.in.response.OrderIdResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 
 @RestController
@@ -34,26 +34,28 @@ public class OrderController {
     private final OrderUseCase orderUseCase;
 
     @PostMapping("/products/{product-id}")
-    public ResponseEntity<Void> orderProduct(@PathVariable("product-id") final long productId,
+    public ResponseEntity<OrderIdResponse> orderProduct(
+        @PathVariable("product-id") final long productId,
         @RequestBody final OrderProductQuantityRequest orderProductQuantityRequest,
         @LoginUser final Long userId) {
 
         final OrderProductRequest orderProductRequest = new OrderProductRequest(userId,
             productId,
             orderProductQuantityRequest.quantity());
-        final long orderId = orderUseCase.orderProduct(orderProductRequest);
 
-        return ResponseEntity.created(URI.create("/v1/orders/" + orderId))
-            .build();
+        final OrderIdResponse orderIdResponse = orderUseCase.orderProduct(orderProductRequest);
+
+        return ResponseEntity.ok(orderIdResponse);
     }
 
     @PostMapping("/carts/{cart-id}")
-    public ResponseEntity<Void> orderCart(@PathVariable("cart-id") final long cartId,
+    public ResponseEntity<OrderIdResponse> orderCart(@PathVariable("cart-id") final long cartId,
         @LoginUser final Long userId) {
-        final long orderId = orderUseCase.orderCartByCartIdAndUserId(cartId, userId);
 
-        return ResponseEntity.created(URI.create("/v1/orders/" + orderId))
-            .build();
+        final OrderIdResponse orderIdResponse = orderUseCase.orderCartByCartIdAndUserId(cartId,
+            userId);
+
+        return ResponseEntity.ok(orderIdResponse);
     }
 
     @GetMapping

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
@@ -2,13 +2,14 @@ package shop.woowasap.order.domain.in;
 
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
 import shop.woowasap.order.domain.in.response.DetailOrderResponse;
+import shop.woowasap.order.domain.in.response.OrderIdResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 
 public interface OrderUseCase {
 
-    long orderProduct(final OrderProductRequest orderProductRequest);
+    OrderIdResponse orderProduct(final OrderProductRequest orderProductRequest);
 
-    long orderCartByCartIdAndUserId(final long cartId, final long userId);
+    OrderIdResponse orderCartByCartIdAndUserId(final long cartId, final long userId);
 
     OrdersResponse getOrderByUserId(final long userId, final int page, final int size);
 

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderIdResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderIdResponse.java
@@ -1,0 +1,5 @@
+package shop.woowasap.order.domain.in.response;
+
+public record OrderIdResponse(long orderId) {
+
+}

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -14,6 +14,7 @@ import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
 import shop.woowasap.order.domain.in.response.DetailOrderProductResponse;
 import shop.woowasap.order.domain.in.response.DetailOrderResponse;
+import shop.woowasap.order.domain.in.response.OrderIdResponse;
 import shop.woowasap.order.domain.in.response.OrderProductResponse;
 import shop.woowasap.order.domain.in.response.OrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
@@ -40,13 +41,13 @@ public class OrderService implements OrderUseCase {
 
     @Override
     @Transactional
-    public long orderProduct(final OrderProductRequest orderProductRequest) {
+    public OrderIdResponse orderProduct(final OrderProductRequest orderProductRequest) {
         final Product product = getProductByProductId(orderProductRequest.productId());
         final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest, product);
 
         orderRepository.persist(order);
         productConnector.consumeProductByProductId(product.getId(), orderProductRequest.quantity());
-        return order.getId();
+        return new OrderIdResponse(order.getId());
     }
 
     private Product getProductByProductId(final long productId) {
@@ -56,7 +57,7 @@ public class OrderService implements OrderUseCase {
 
     @Override
     @Transactional
-    public long orderCartByCartIdAndUserId(final long cartId, final long userId) {
+    public OrderIdResponse orderCartByCartIdAndUserId(final long cartId, final long userId) {
         final Cart cart = cartConnector.findByCartIdAndUserId(cartId, userId)
             .orElseThrow(() -> new DoesNotFindCartException(cartId, userId));
 
@@ -66,7 +67,7 @@ public class OrderService implements OrderUseCase {
         cart.getCartProducts()
             .forEach(cartProduct -> productConnector.consumeProductByProductId(
                 cartProduct.getProduct().getId(), cartProduct.getQuantity().getValue()));
-        return order.getId();
+        return new OrderIdResponse(order.getId());
     }
 
     @Override

--- a/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
@@ -23,6 +23,7 @@ import shop.woowasap.order.domain.exception.DoesNotFindProductException;
 import shop.woowasap.order.domain.in.OrderUseCase;
 import shop.woowasap.order.domain.in.request.OrderProductRequest;
 import shop.woowasap.order.domain.in.response.DetailOrderResponse;
+import shop.woowasap.order.domain.in.response.OrderIdResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.order.domain.out.OrderRepository;
 import shop.woowasap.order.domain.out.response.OrdersPaginationResponse;
@@ -78,10 +79,10 @@ class OrderServiceTest {
                     .build()));
 
             // when
-            final long result = orderUseCase.orderProduct(orderProductRequest);
+            final OrderIdResponse result = orderUseCase.orderProduct(orderProductRequest);
 
             // then
-            assertThat(result).isEqualTo(orderId);
+            assertThat(result.orderId()).isEqualTo(orderId);
         }
 
         @Test
@@ -128,10 +129,10 @@ class OrderServiceTest {
             when(idGenerator.generate()).thenReturn(orderId);
 
             // when
-            final long result = orderUseCase.orderCartByCartIdAndUserId(cartId, userId);
+            final OrderIdResponse result = orderUseCase.orderCartByCartIdAndUserId(cartId, userId);
 
             // then
-            assertThat(result).isEqualTo(orderId);
+            assertThat(result.orderId()).isEqualTo(orderId);
         }
 
         @Test


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
주문성공시, `OrderIdResponse` 와 `Ok` 를 반환하도록 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 인수테스트 검증 수정
- [x] Service에서 OrderIdResponse 를 반환하도록 수정
- [x] Order Service test 수정

## 🦀 이슈 넘버
- resolve #196 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
