### PR TITLE
feat: Product 전체 조회를 startTime 기준으로 정렬

### DIFF
--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/ProductRepositoryImpl.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/ProductRepositoryImpl.java
@@ -6,10 +6,11 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
-import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.ProductRepository;
 import shop.woowasap.shop.domain.out.response.ProductsPaginationResponse;
+import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.repository.entity.ProductEntity;
 import shop.woowasap.shop.repository.jpa.ProductJpaRepository;
 
@@ -39,7 +40,8 @@ public class ProductRepositoryImpl implements ProductRepository {
 
     @Override
     public ProductsPaginationResponse findAllValidWithPagination(final int page, final int size) {
-        final PageRequest pageRequest = PageRequest.of(page - 1, size);
+        final PageRequest pageRequest = PageRequest.of(page - 1, size,
+            Sort.by("startTime").ascending());
         final Page<ProductEntity> pagination = productJpaRepository.findAllByEndTimeAfter(
             Instant.now(), pageRequest);
 
@@ -52,7 +54,8 @@ public class ProductRepositoryImpl implements ProductRepository {
 
     @Override
     public ProductsPaginationResponse findAllWithPagination(final int page, final int size) {
-        final PageRequest pageRequest = PageRequest.of(page - 1, size);
+        final PageRequest pageRequest = PageRequest.of(page - 1, size,
+            Sort.by("startTime").ascending());
         final Page<ProductEntity> pagination = productJpaRepository.findAll(pageRequest);
 
         final List<Product> products = pagination.get()

--- a/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
+++ b/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
@@ -2,7 +2,6 @@ package shop.woowasap.shop.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -14,8 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 import shop.woowasap.BeanScanBaseLocation;
-import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.response.ProductsPaginationResponse;
+import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.repository.support.ProductFixture;
 
 @DataJpaTest
@@ -158,7 +157,7 @@ class ProductRepositoryImplTest {
     class findAllValidWithPaginationMethod {
 
         @Test
-        @DisplayName("판매 예정이거나 판매 중인 Product 들을 반환한다.")
+        @DisplayName("판매 예정이거나 판매 중인 Product 들을 startTime 기준 오름차순으로 반환한다.")
         void returnAllValidProducts() {
             // given
             final int page = 1;
@@ -166,12 +165,12 @@ class ProductRepositoryImplTest {
             final int totalPage = 1;
 
             final Product salePastProduct = ProductFixture.salePastProduct(1L);
-            final Product onSaleProduct = ProductFixture.onSaleProduct(2L);
-            final Product salePriorProduct = ProductFixture.salePriorProduct(3L);
+            final Product salePriorProduct = ProductFixture.salePriorProduct(2L);
+            final Product onSaleProduct = ProductFixture.onSaleProduct(3L);
 
             productRepository.persist(salePastProduct);
-            productRepository.persist(onSaleProduct);
             productRepository.persist(salePriorProduct);
+            productRepository.persist(onSaleProduct);
 
             ProductsPaginationResponse expected = new ProductsPaginationResponse(
                 List.of(onSaleProduct, salePriorProduct),
@@ -194,7 +193,7 @@ class ProductRepositoryImplTest {
     class findAllWithPaginationMethod {
 
         @Test
-        @DisplayName("모든 Product 들을 반환한다.")
+        @DisplayName("모든 Product 들을 startTime 기준 오름차순으로 반환한다.")
         void returnAllProducts() {
             // given
             final int page = 1;
@@ -202,15 +201,15 @@ class ProductRepositoryImplTest {
             final int totalPage = 1;
 
             final Product salePastProduct = ProductFixture.salePastProduct(1L);
-            final Product onSaleProduct = ProductFixture.onSaleProduct(2L);
-            final Product salePriorProduct = ProductFixture.salePriorProduct(3L);
+            final Product salePriorProduct = ProductFixture.salePriorProduct(2L);
+            final Product onSaleProduct = ProductFixture.onSaleProduct(3L);
 
             productRepository.persist(salePastProduct);
-            productRepository.persist(onSaleProduct);
             productRepository.persist(salePriorProduct);
+            productRepository.persist(onSaleProduct);
 
             ProductsPaginationResponse expected = new ProductsPaginationResponse(
-                List.of(salePastProduct, onSaleProduct, salePriorProduct),
+                List.of(onSaleProduct, salePastProduct, salePriorProduct),
                 page,
                 totalPage
             );


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- Product 전체 조회를 startTime 기준으로 정렬한다

## 🕶️ 어떻게 해결했나요?
- PageRequest 에 startTime 기준 오름 차순 정렬 추가

## 🦀 이슈 넘버
- close #178 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
