### PR TITLE
feat: Product 상세 조회 시, 판매가 끝난 Product 일 경우 예외 발생

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/exception/SaleEndedProductException.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/exception/SaleEndedProductException.java
@@ -1,0 +1,8 @@
+package shop.woowasap.shop.domain.exception;
+
+public class SaleEndedProductException extends ProductException {
+
+    public SaleEndedProductException(final String message) {
+        super(message);
+    }
+}

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/out/ProductRepository.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/out/ProductRepository.java
@@ -1,16 +1,14 @@
 package shop.woowasap.shop.domain.out;
 
 import java.util.Optional;
-import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.response.ProductsPaginationResponse;
+import shop.woowasap.shop.domain.product.Product;
 
 public interface ProductRepository {
 
     Product persist(final Product product);
 
     Optional<Product> findById(final long productId);
-
-    Optional<Product> findByIdAndValidSaleTime(final long productId);
 
     ProductsPaginationResponse findAllValidWithPagination(final int page, final int size);
 

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/product/Product.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/product/Product.java
@@ -60,4 +60,8 @@ public final class Product {
             throw new InvalidProductSaleTimeException();
         }
     }
+
+    public boolean isEndTimeBefore(final Instant time) {
+        return endTime.isBefore(time);
+    }
 }

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/ProductTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/ProductTest.java
@@ -168,4 +168,46 @@ class ProductTest {
             assertThat(update).usingRecursiveAssertion().isEqualTo(expected);
         }
     }
+
+    @Nested
+    @DisplayName("isEndTimeBefore 메서드는")
+    class IsEndTimeBefore_Method {
+
+        @Test
+        @DisplayName("EndTime 이 time 이전이라면 true 를 반환한다.")
+        void returnTrueWhenEndTimeIsBeforeTime() {
+            // given
+            final Product product = getDefaultBuilder()
+                .startTime(Instant.now().minusSeconds(1_000))
+                .endTime(Instant.now().plusSeconds(1_000))
+                .build();
+
+            final Instant time = Instant.now().plusSeconds(10_000);
+
+            // when
+            final boolean result = product.isEndTimeBefore(time);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("EndTime 이 time 이후라면 false 를 반환한다.")
+        void returnFalseWhenEndTimeIsAfterTime() {
+            // given
+            final Product product = getDefaultBuilder()
+                .startTime(Instant.now().minusSeconds(1_000))
+                .endTime(Instant.now().plusSeconds(1_000))
+                .build();
+
+            final Instant time = Instant.now();
+
+            // when
+            final boolean result = product.isEndTimeBefore(time);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
 }

--- a/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/ProductRepositoryImpl.java
+++ b/shop/shop-repository/src/main/java/shop/woowasap/shop/repository/ProductRepositoryImpl.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
-import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.ProductRepository;
 import shop.woowasap.shop.domain.out.response.ProductsPaginationResponse;
+import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.repository.entity.ProductEntity;
 import shop.woowasap.shop.repository.jpa.ProductJpaRepository;
 
@@ -28,12 +28,6 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public Optional<Product> findById(final long productId) {
         return productJpaRepository.findById(productId)
-            .map(ProductEntity::toDomain);
-    }
-
-    @Override
-    public Optional<Product> findByIdAndValidSaleTime(final long productId) {
-        return productJpaRepository.findByIdAndEndTimeAfter(productId, Instant.now())
             .map(ProductEntity::toDomain);
     }
 

--- a/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
+++ b/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
@@ -2,7 +2,6 @@ package shop.woowasap.shop.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -14,8 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 import shop.woowasap.BeanScanBaseLocation;
-import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.out.response.ProductsPaginationResponse;
+import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.repository.support.ProductFixture;
 
 @DataJpaTest
@@ -95,57 +94,6 @@ class ProductRepositoryImplTest {
 
             // when
             final Optional<Product> result = productRepository.findById(notExistProductId);
-
-            // then
-            assertThat(result).isEmpty();
-        }
-
-    }
-
-    @Nested
-    @DisplayName("findByAndValidSaleTime 메서드는")
-    class findByAndValidSaleTimeMethod {
-
-        @Test
-        @DisplayName("productId 에 해당하는 product 가 판매 중인 상품이라면 Product 를 반환한다.")
-        void returnValidProductWhenOnSaleProduct() {
-            // given
-            final Product onSaleProduct = ProductFixture.onSaleProduct(1L);
-            productRepository.persist(onSaleProduct);
-
-            // when
-            final Optional<Product> result = productRepository.findByIdAndValidSaleTime(
-                onSaleProduct.getId());
-
-            // then
-            assertThat(result.get()).usingRecursiveComparison().isEqualTo(onSaleProduct);
-        }
-
-        @Test
-        @DisplayName("productId 에 해당하는 product 가 판매 예정인 상품이라면 Product 를 반환한다.")
-        void returnValidProductWhenSalePriorProduct() {
-            // given
-            final Product salePriorProduct = ProductFixture.salePriorProduct(1L);
-            productRepository.persist(salePriorProduct);
-
-            // when
-            final Optional<Product> result = productRepository.findByIdAndValidSaleTime(
-                salePriorProduct.getId());
-
-            // then
-            assertThat(result.get()).usingRecursiveComparison().isEqualTo(salePriorProduct);
-        }
-
-        @Test
-        @DisplayName("productId 에 해당하는 product 가 판매가 지난 상품이라면 Null 을 반환한다.")
-        void returnNullWhenSalePastProduct() {
-            // given
-            final Product salePastProduct = ProductFixture.salePastProduct(1L);
-            productRepository.persist(salePastProduct);
-
-            // when
-            final Optional<Product> result = productRepository.findByIdAndValidSaleTime(
-                salePastProduct.getId());
 
             // then
             assertThat(result).isEmpty();


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- Product 상세 조회 시, 판매가 끝난 Product 일 경우 예외가 발생하도록 수정한다.

## 🕶️ 어떻게 해결했나요?
- [x] 판매가 종료된 상품일 경우 SaleEndedProductException 발생
- [x] productId 에 해당하는 상품이 존재하지 않을 경우 NotExistsProductException 발생 

## 🦀 이슈 넘버
- close #177 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
