### PR TITLE
feat: 장바구니 상품 Response 에 상품의 남은 재고 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/CartAcceptanceTest.java
@@ -85,7 +85,8 @@ class CartAcceptanceTest extends AcceptanceTest {
             quantity);
         CartApiSupporter.addCartProduct(accessToken, addCartProductRequest);
 
-        final CartResponse expected = cartResponse(productId, quantity);
+        final CartResponse expected = cartResponse(productId, quantity,
+            registerProductRequest.quantity());
 
         // when
         final ExtractableResponse<Response> response = getCartProducts(accessToken);
@@ -110,7 +111,8 @@ class CartAcceptanceTest extends AcceptanceTest {
             5L);
         CartApiSupporter.addCartProduct(accessToken, addCartProductRequest);
 
-        final CartResponse expected = cartResponse(productId, updatedQuantity);
+        final CartResponse expected = cartResponse(productId, updatedQuantity,
+            updateCartProductRequest.quantity());
 
         // when
         CartApiSupporter.updateCartProduct(accessToken, updateCartProductRequest);

--- a/app/src/test/java/shop/woowasap/accept/support/fixture/CartFixture.java
+++ b/app/src/test/java/shop/woowasap/accept/support/fixture/CartFixture.java
@@ -25,10 +25,10 @@ public final class CartFixture {
         return new UpdateCartProductRequest(productId, quantity);
     }
 
-    public static CartResponse cartResponse(final long productId, final long purchaseQuantity,
-        final long remainQuantity) {
+    public static CartResponse cartResponse(final long productId, final long quantity,
+        final long remainProductQuantity) {
         final CartProductResponse cartProduct = new CartProductResponse(productId, NAME, PRICE,
-            purchaseQuantity, remainQuantity);
+            quantity, remainProductQuantity);
 
         return new CartResponse(CART_ID, List.of(cartProduct));
     }

--- a/app/src/test/java/shop/woowasap/accept/support/fixture/CartFixture.java
+++ b/app/src/test/java/shop/woowasap/accept/support/fixture/CartFixture.java
@@ -25,9 +25,10 @@ public final class CartFixture {
         return new UpdateCartProductRequest(productId, quantity);
     }
 
-    public static CartResponse cartResponse(final long productId, final long quantity) {
+    public static CartResponse cartResponse(final long productId, final long purchaseQuantity,
+        final long remainQuantity) {
         final CartProductResponse cartProduct = new CartProductResponse(productId, NAME, PRICE,
-            quantity);
+            purchaseQuantity, remainQuantity);
 
         return new CartResponse(CART_ID, List.of(cartProduct));
     }

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/in/cart/response/CartProductResponse.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/in/cart/response/CartProductResponse.java
@@ -1,6 +1,6 @@
 package shop.woowasap.shop.domain.in.cart.response;
 
-public record CartProductResponse(long productId, String name, String price, long purchaseQuantity,
-                                  long remainQuantity) {
+public record CartProductResponse(long productId, String name, String price, long quantity,
+                                  long productRemainQuantity) {
 
 }

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/in/cart/response/CartProductResponse.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/in/cart/response/CartProductResponse.java
@@ -1,5 +1,6 @@
 package shop.woowasap.shop.domain.in.cart.response;
 
-public record CartProductResponse(long productId, String name, String price, long quantity) {
+public record CartProductResponse(long productId, String name, String price, long purchaseQuantity,
+                                  long remainQuantity) {
 
 }

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/mapper/CartMapper.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/mapper/CartMapper.java
@@ -18,6 +18,7 @@ public final class CartMapper {
                 cartProduct.getProduct().getId(),
                 cartProduct.getProduct().getName().getValue(),
                 cartProduct.getProduct().getPrice().getValue().toString(),
+                cartProduct.getQuantity().getValue(),
                 cartProduct.getProduct().getQuantity().getValue()
             )).toList();
 

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/support/fixture/CartFixture.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/support/fixture/CartFixture.java
@@ -93,6 +93,7 @@ public final class CartFixture {
             cartProduct.getProduct().getId(),
             cartProduct.getProduct().getName().getValue(),
             cartProduct.getProduct().getPrice().getValue().toString(),
+            cartProduct.getQuantity().getValue(),
             cartProduct.getProduct().getQuantity().getValue()
         );
     }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

장바구니 상품 Response 에 상품의 남은 재고를 추가했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] CartProductResponse 에 `remainProductQuantity` 추가
- [x] CartMapper 수정
- [x] CartResponse Fixture 수정

## 🦀 이슈 넘버

- close #180 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
