### PR TITLE
refactor: order 모듈 `Instant.now() -> TimeUtil.now()` 로 변경

### DIFF
--- a/order/order-service/build.gradle
+++ b/order/order-service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':core:util')
     implementation project(':core:id-gen')
     implementation project(':shop:shop-domain')
     implementation project(':order:order-domain')

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.woowasap.core.id.api.IdGenerator;
+import shop.woowasap.core.util.time.TimeUtil;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.exception.DoesNotFindCartException;
 import shop.woowasap.order.domain.exception.DoesNotFindOrderException;
@@ -21,9 +22,9 @@ import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.order.domain.out.OrderRepository;
 import shop.woowasap.order.domain.out.response.OrdersPaginationResponse;
 import shop.woowasap.order.service.mapper.OrderMapper;
+import shop.woowasap.shop.domain.cart.Cart;
 import shop.woowasap.shop.domain.in.cart.CartConnector;
 import shop.woowasap.shop.domain.in.product.ProductConnector;
-import shop.woowasap.shop.domain.cart.Cart;
 import shop.woowasap.shop.domain.product.Product;
 
 @Service
@@ -35,6 +36,7 @@ public class OrderService implements OrderUseCase {
     private final ProductConnector productConnector;
     private final CartConnector cartConnector;
     private final OrderRepository orderRepository;
+    private final TimeUtil timeUtil;
 
     @Value("${shop.woowasap.locale:Asia/Seoul}")
     private String locale;
@@ -43,7 +45,7 @@ public class OrderService implements OrderUseCase {
     @Transactional
     public OrderIdResponse orderProduct(final OrderProductRequest orderProductRequest) {
         final Product product = getProductByProductId(orderProductRequest.productId());
-        final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest, product);
+        final Order order = OrderMapper.toDomain(idGenerator, orderProductRequest, product, timeUtil.now());
 
         orderRepository.persist(order);
 
@@ -61,7 +63,7 @@ public class OrderService implements OrderUseCase {
         final Cart cart = cartConnector.findByCartIdAndUserId(cartId, userId)
             .orElseThrow(() -> new DoesNotFindCartException(cartId, userId));
 
-        final Order order = OrderMapper.toDomain(idGenerator, userId, cart);
+        final Order order = OrderMapper.toDomain(idGenerator, userId, cart, timeUtil.now());
 
         orderRepository.persist(order);
 

--- a/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
@@ -1,6 +1,7 @@
 package shop.woowasap.order.service.mapper;
 
 import java.math.BigInteger;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -23,16 +24,17 @@ public final class OrderMapper {
     }
 
     public static Order toDomain(final IdGenerator idGenerator,
-        final OrderProductRequest orderProductRequest, final Product product) {
+        final OrderProductRequest orderProductRequest, final Product product, final Instant createdAt) {
         return Order.builder()
             .id(idGenerator.generate())
             .userId(orderProductRequest.userId())
             .orderProducts(List.of(toOrderProduct(product, orderProductRequest.quantity())))
+            .createdAt(createdAt)
             .build();
     }
 
     public static Order toDomain(final IdGenerator idGenerator, final long userId,
-        final Cart cart) {
+        final Cart cart, final Instant createdAt) {
         final List<OrderProduct> orderProducts = cart.getCartProducts()
             .stream()
             .map(cartProduct -> toOrderProduct(cartProduct.getProduct(),
@@ -43,6 +45,7 @@ public final class OrderMapper {
             .id(idGenerator.generate())
             .userId(userId)
             .orderProducts(orderProducts)
+            .createdAt(createdAt)
             .build();
     }
 

--- a/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import shop.woowasap.core.id.api.IdGenerator;
+import shop.woowasap.core.util.time.TimeUtil;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.OrderProduct;
 import shop.woowasap.order.domain.exception.DoesNotFindCartException;
@@ -32,10 +35,10 @@ import shop.woowasap.order.service.support.fixture.OrderDtoFixture;
 import shop.woowasap.order.service.support.fixture.OrderFixture;
 import shop.woowasap.order.service.support.fixture.OrderProductFixture;
 import shop.woowasap.order.service.support.fixture.ProductFixture;
-import shop.woowasap.shop.domain.in.cart.CartConnector;
-import shop.woowasap.shop.domain.in.product.ProductConnector;
 import shop.woowasap.shop.domain.cart.Cart;
 import shop.woowasap.shop.domain.cart.CartProduct;
+import shop.woowasap.shop.domain.in.cart.CartConnector;
+import shop.woowasap.shop.domain.in.product.ProductConnector;
 import shop.woowasap.shop.domain.product.Product;
 
 @DisplayName("OrderService 클래스")
@@ -57,6 +60,14 @@ class OrderServiceTest {
 
     @MockBean
     private OrderRepository orderRepository;
+
+    @MockBean
+    private TimeUtil timeUtil;
+
+    @BeforeEach
+    void setUpTime() {
+        when(timeUtil.now()).thenReturn(Instant.now());
+    }
 
     @Nested
     @DisplayName("orderProduct 메소드는")


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
refactor: order 모듈 `Instant.now() -> TimeUtil.now()` 과 같이 변경했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] order-service 모듈의 build.gradle에 `core:util` 정의 후, OrderMapper 메소드에서, TimeUtil.now 를 받도록 수정

## 🦀 이슈 넘버
- close #193 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
