### PR TITLE
refactor: CartProduct의 수량을 최소 1개 최대 10개로 설정

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProduct.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProduct.java
@@ -24,7 +24,7 @@ public class CartProduct {
     public CartProduct addQuantity(final CartProductQuantity quantity) {
         return CartProduct.builder()
             .product(this.product)
-            .quantity(this.quantity.addQuantity(quantity))
+            .quantity(this.quantity.addQuantity(quantity, this.product.getQuantity()))
             .build();
     }
 

--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProductQuantity.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProductQuantity.java
@@ -4,26 +4,45 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import shop.woowasap.shop.domain.exception.InvalidCartProductQuantityException;
+import shop.woowasap.shop.domain.product.Quantity;
 
 @Getter
 @ToString
 @EqualsAndHashCode
 public final class CartProductQuantity {
 
+    private static final long MAX_CART_PRODUCT_QUANTITY = 10L;
+    private static final long MIN_CART_PRODUCT_QUANTITY = 1L;
     private final Long value;
 
-    public CartProductQuantity(final Long value) {
+    public CartProductQuantity(final Long value, final Quantity quantity) {
         validate(value);
-        this.value = value;
+        this.value = getBoundValue(value, quantity.getValue());
+    }
+
+    public CartProductQuantity(final Long value) {
+        this(value, new Quantity(MAX_CART_PRODUCT_QUANTITY));
     }
 
     private void validate(final Long value) {
-        if (value == null || value <= 0) {
+        if (value == null) {
             throw new InvalidCartProductQuantityException("해당 장바구니의 상품 수량이 입력이 잘못되었습니다.");
         }
     }
 
-    public CartProductQuantity addQuantity(final CartProductQuantity quantity) {
-        return new CartProductQuantity(this.value + quantity.value);
+    private long getBoundValue(final Long value, final Long remainQuantity) {
+        final long maxCartProductQuantity = Math.min(MAX_CART_PRODUCT_QUANTITY, remainQuantity);
+        if (value > maxCartProductQuantity) {
+            return maxCartProductQuantity;
+        }
+        if (value < MIN_CART_PRODUCT_QUANTITY) {
+            return MIN_CART_PRODUCT_QUANTITY;
+        }
+        return value;
+    }
+
+    public CartProductQuantity addQuantity(final CartProductQuantity quantity,
+        final Quantity remainQuantity) {
+        return new CartProductQuantity(this.value + quantity.value, remainQuantity);
     }
 }

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartTest.java
@@ -50,11 +50,29 @@ class CartTest {
         }
 
         @Test
+        @DisplayName("해당 상품의 재고가 장바구니에 담으려는 재고보다 적고, 해당 상품이 장바구니에 없는 경우 장바구니에 상품의 재고 만큼 추가된다.")
+        void addCartProductWithNotExistsWithMaxProductQuantity() {
+            // given
+            final long remainQuantity = 5L;
+            final Product product = getDefaultBuilder().quantity(remainQuantity).build();
+            final CartProduct cartProduct = getCartProductBuilder(product, 10L).build();
+            final Cart cart = getEmptyCartBuilder().build();
+
+            // when
+            cart.addProduct(cartProduct);
+
+            // then
+            assertThat(cart.getCartProducts()).hasSize(1);
+            assertThat(cart.getCartProducts().get(0).getQuantity().getValue()).isEqualTo(5L);
+        }
+
+        @Test
         @DisplayName("해당 상품이 있는 경우 장바구니의 해당 상품의 개수가 증가한다.")
         void addCartProductWithExists() {
             // given
-            final long quantity = 10L;
-            final CartProduct cartProduct = getCartProductBuilder().build();
+            final long quantity = 3L;
+            final CartProduct cartProduct = getCartProductBuilder().quantity(
+                new CartProductQuantity(quantity)).build();
             final List<CartProduct> cartProducts = new ArrayList<>();
             cartProducts.add(cartProduct);
             final Cart cart = getEmptyCartBuilder()
@@ -67,6 +85,27 @@ class CartTest {
             assertThat(cart.getCartProducts()).hasSize(1);
             assertThat(cart.getCartProducts().get(0).getQuantity()).isEqualTo(
                 new CartProductQuantity(quantity + quantity));
+        }
+
+        @Test
+        @DisplayName("상품의 재고가 기존에 장바구니에 담겨져 있는 재고와 합쳐지는 재고의 양보다 적으면, 상품의 최대 재고로 변경된다.")
+        void addCartProductQuantityWithMaxProductQuantity() {
+            // given
+            final long remainQuantity = 5L;
+            final Product product = getDefaultBuilder().quantity(remainQuantity)
+                .build();
+            final CartProduct cartProduct = getCartProductBuilder(product, 4L).build();
+            final List<CartProduct> cartProducts = new ArrayList<>();
+            cartProducts.add(cartProduct);
+            final Cart cart = getEmptyCartBuilder().cartProducts(cartProducts).build();
+
+            // when
+            cart.addProduct(cartProduct);
+
+            // then
+            assertThat(cart.getCartProducts()).hasSize(1);
+            assertThat(cart.getCartProducts().get(0).getQuantity()).isEqualTo(
+                new CartProductQuantity(remainQuantity));
         }
     }
 
@@ -133,7 +172,7 @@ class CartTest {
             // given
             final List<CartProduct> cartProducts = new ArrayList<>();
             cartProducts.add(getCartProductBuilder().build());
-            final CartProductQuantity updateCartProductQuantity = new CartProductQuantity(20L);
+            final CartProductQuantity updateCartProductQuantity = new CartProductQuantity(5L);
             final CartProduct updateCartProduct = getCartProductBuilder()
                 .quantity(updateCartProductQuantity).build();
             final Cart cart = getEmptyCartBuilder().cartProducts(cartProducts).build();
@@ -145,6 +184,27 @@ class CartTest {
             assertThat(cart.getCartProducts()).hasSize(1);
             assertThat(cart.getCartProducts().get(0).getQuantity()).isEqualTo(
                 updateCartProductQuantity);
+        }
+
+        @Test
+        @DisplayName("상품의 재고가 바꾸려는 개수보다 적으면, 상품의 최대 재고로 변경된다.")
+        void updateCartProductQuantityWithMaxProductQuantity() {
+            // given
+            final long remainQuantity = 5L;
+            final Product product = getDefaultBuilder().quantity(remainQuantity)
+                .build();
+            final List<CartProduct> cartProducts = new ArrayList<>();
+            cartProducts.add(getCartProductBuilder(product, 3L).build());
+            final CartProduct updateCartProduct = getCartProductBuilder(product, 10L).build();
+            final Cart cart = getEmptyCartBuilder().cartProducts(cartProducts).build();
+
+            // when
+            cart.updateCartProduct(updateCartProduct);
+
+            // then
+            assertThat(cart.getCartProducts()).hasSize(1);
+            assertThat(cart.getCartProducts().get(0).getQuantity().getValue())
+                .isEqualTo(remainQuantity);
         }
     }
 }

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/support/CartFixture.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/support/CartFixture.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import shop.woowasap.shop.domain.cart.Cart;
 import shop.woowasap.shop.domain.cart.CartProduct;
 import shop.woowasap.shop.domain.cart.CartProductQuantity;
+import shop.woowasap.shop.domain.product.Product;
 
 public final class CartFixture {
 
@@ -21,5 +22,12 @@ public final class CartFixture {
         return CartProduct.builder()
             .product(DomainFixture.getDefaultBuilder().build())
             .quantity(new CartProductQuantity(10L));
+    }
+
+    public static CartProduct.CartProductBuilder getCartProductBuilder(final Product product,
+        final long quantity) {
+        return CartProduct.builder()
+            .product(product)
+            .quantity(new CartProductQuantity(quantity, product.getQuantity()));
     }
 }

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/CartService.java
@@ -41,7 +41,7 @@ public class CartService implements CartUseCase {
 
         cart.updateCartProduct(CartProduct.builder()
             .product(product)
-            .quantity(new CartProductQuantity(updateCartProductRequest.quantity()))
+            .quantity(new CartProductQuantity(updateCartProductRequest.quantity(), product.getQuantity()))
             .build());
         cartRepository.persist(cart);
     }
@@ -59,7 +59,7 @@ public class CartService implements CartUseCase {
 
         cart.addProduct(CartProduct.builder()
             .product(product)
-            .quantity(new CartProductQuantity(addCartProductRequest.quantity()))
+            .quantity(new CartProductQuantity(addCartProductRequest.quantity(), product.getQuantity()))
             .build());
         cartRepository.persist(cart);
     }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

CartProduct의 수량을 최소 1개 최대 10개로 설정했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] CartProduct에서 Product의 Quantity를 받아서 최대 수량을 비교하도록 수정
- [x] CartProduct에서 최대 수량, 최소 수량을 관리하도록 추가

## 🦀 이슈 넘버

- close #179 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
