### PR TITLE
feat: `OrderConnector` 인터페이스 구현

### DIFF
--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderConnector.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderConnector.java
@@ -5,6 +5,6 @@ import shop.woowasap.order.domain.Order;
 
 public interface OrderConnector {
 
-    Optional<Order> findByOrderId(final long orderId);
+    Optional<Order> findByOrderIdAndUserId(final long orderId, final long userId);
 
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderConnectorService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderConnectorService.java
@@ -1,0 +1,20 @@
+package shop.woowasap.order.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.in.OrderConnector;
+import shop.woowasap.order.domain.out.OrderRepository;
+
+@Service
+@RequiredArgsConstructor
+public class OrderConnectorService implements OrderConnector {
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public Optional<Order> findByOrderIdAndUserId(final long orderId, final long userId) {
+        return orderRepository.findOrderByOrderIdAndUserId(orderId, userId);
+    }
+}

--- a/order/order-service/src/test/java/shop/woowasap/order/service/OrderConnectorServiceTest.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/OrderConnectorServiceTest.java
@@ -1,0 +1,79 @@
+package shop.woowasap.order.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.OrderProduct;
+import shop.woowasap.order.domain.out.OrderRepository;
+import shop.woowasap.order.service.support.fixture.OrderFixture;
+import shop.woowasap.order.service.support.fixture.OrderProductFixture;
+import shop.woowasap.order.service.support.fixture.ProductFixture;
+import shop.woowasap.shop.domain.product.Product;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("OrderConnectorService 클래스")
+@ContextConfiguration(classes = OrderConnectorService.class)
+class OrderConnectorServiceTest {
+
+    @Autowired
+    private OrderConnectorService orderConnectorService;
+
+    @MockBean
+    private OrderRepository orderRepository;
+
+    @Nested
+    @DisplayName("findByOrderIdAndUserId 메소드는")
+    class findByOrderIdAndUserIdMethod {
+
+        @Test
+        @DisplayName("orderId와 userId를 받아, 일치하는 Order를 반환한다.")
+        void returnMatchedOrderWithOrderIdAndUserId() {
+            // given
+            final long orderId = 1L;
+            final long userId = 1L;
+
+            final Product product = ProductFixture.getDefaultBuilder().build();
+            final OrderProduct orderProduct = OrderProductFixture.from(product);
+            final Order order = OrderFixture.getDefault(List.of(orderProduct));
+
+            when(orderRepository.findOrderByOrderIdAndUserId(orderId, userId))
+                .thenReturn(Optional.of(order));
+
+            // when
+            final Optional<Order> result = orderConnectorService.findByOrderIdAndUserId(orderId, userId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).usingRecursiveComparison().isEqualTo(order);
+        }
+
+        @Test
+        @DisplayName("orderId와 userId가 일치하는 Order를 찾을 수 없으면, Optional.empty를 반환한다.")
+        void returnEmptyOptionalWhenCannotFindMatchedOrder() {
+            // given
+            final long orderId = 1L;
+            final long userId = 1L;
+
+            when(orderRepository.findOrderByOrderIdAndUserId(orderId, userId))
+                .thenReturn(Optional.empty());
+
+            // when
+            final Optional<Order> result = orderConnectorService.findByOrderIdAndUserId(orderId, userId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
`OrderConnector` 인터페이스를 구현했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `OrderConnector` 구현
- [x] 관련 테스트 작성
- [x] 시그니처 `findByOrderId(final long orderId)` -> `findByOrderIdAndUserId(final long orderId, final long userId)` 로 변경

## 🦀 이슈 넘버
- close #207 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
