### PR TITLE
test: `Order` -> `Payment` 검증 테스트 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,11 @@ dependencies {
     implementation project(':order:order-controller')
     implementation project(':order:order-repository')
 
+    implementation project(':payment:payment-domain')
+    implementation project(':payment:payment-service')
+    implementation project(':payment:payment-controller')
+    implementation project(':payment:payment-repository')
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -1,7 +1,5 @@
 package shop.woowasap.accept;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.math.BigInteger;
@@ -25,7 +23,6 @@ import shop.woowasap.order.domain.in.response.OrderResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 import shop.woowasap.shop.domain.in.cart.request.AddCartProductRequest;
 import shop.woowasap.shop.domain.in.cart.response.CartResponse;
-import shop.woowasap.shop.domain.in.product.response.ProductDetailsResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductsResponse;
 
@@ -122,7 +119,7 @@ class OrderAcceptanceTest extends AcceptanceTest {
                 quantity);
         final DetailOrderResponse expectedDetailOrderResponse = new DetailOrderResponse(orderId,
             List.of(expectedDetailOrderProductResponse),
-            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(),
+            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(), "PENDING",
             LocalDateTime.now());
 
         // when

--- a/app/src/test/java/shop/woowasap/accept/PayOrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/PayOrderAcceptanceTest.java
@@ -1,0 +1,125 @@
+package shop.woowasap.accept;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.woowasap.accept.support.api.AuthApiSupporter;
+import shop.woowasap.accept.support.api.OrderApiSupporter;
+import shop.woowasap.accept.support.api.PayApiSupporter;
+import shop.woowasap.accept.support.api.ShopApiSupporter;
+import shop.woowasap.accept.support.fixture.ProductFixture;
+import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
+import shop.woowasap.order.domain.in.response.DetailOrderResponse;
+import shop.woowasap.order.domain.in.response.OrderIdResponse;
+import shop.woowasap.payment.controller.request.PayRequest;
+import shop.woowasap.shop.domain.in.product.response.ProductDetailsResponse;
+import shop.woowasap.shop.domain.in.product.response.ProductResponse;
+import shop.woowasap.shop.domain.in.product.response.ProductsResponse;
+
+@DisplayName("Pay Order 인수테스트")
+class PayOrderAcceptanceTest extends AcceptanceTest {
+
+    private String accessToken;
+
+    @BeforeEach
+    void setAccessToken() {
+        accessToken = AuthApiSupporter.adminAccessToken();
+    }
+
+    @Test
+    @DisplayName("결제에 성공하면, Product quantity가 줄어들고, Order의 상태가 SUCCESS로 변경된다")
+    void decreaseProductQuantityWhenPaySuccess() {
+        // given
+        final long productId = getRandomProduct(accessToken).productId();
+        final int quantity = 2;
+        final OrderProductQuantityRequest orderProductRequest = new OrderProductQuantityRequest(
+            quantity);
+        final OrderIdResponse orderIdResponse = OrderApiSupporter.orderProduct(productId,
+            orderProductRequest,
+            accessToken).as(OrderIdResponse.class);
+
+        final PayRequest payRequest = new PayRequest("CARD", true);
+
+        // when
+        PayApiSupporter.pay(payRequest, orderIdResponse.orderId(), accessToken);
+
+        // then
+        final ProductDetailsResponse productResponse = ShopApiSupporter.getProduct(productId)
+            .as(ProductDetailsResponse.class);
+        final DetailOrderResponse orderResponse = OrderApiSupporter.getOrderByOrderId(orderIdResponse.orderId(),
+                accessToken)
+            .as(DetailOrderResponse.class);
+
+        assertThat(productResponse.quantity()).isEqualTo(8);
+        assertThat(orderResponse.type()).isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("결제에 실패하면, Product quantity가 그대로 남고, Order의 상태가 PENDING상태가 유지된다.")
+    void payFailOrderStatusPending() {
+        // given
+        final long productId = getRandomProduct(accessToken).productId();
+        final int quantity = 2;
+        final OrderProductQuantityRequest orderProductRequest = new OrderProductQuantityRequest(
+            quantity);
+        final OrderIdResponse orderIdResponse = OrderApiSupporter.orderProduct(productId,
+            orderProductRequest,
+            accessToken).as(OrderIdResponse.class);
+
+        final PayRequest payRequest = new PayRequest("CARD", false);
+
+        // when
+        PayApiSupporter.pay(payRequest, orderIdResponse.orderId(), accessToken);
+
+        // then
+        final ProductDetailsResponse productResponse = ShopApiSupporter.getProduct(productId)
+            .as(ProductDetailsResponse.class);
+        final DetailOrderResponse orderResponse = OrderApiSupporter.getOrderByOrderId(orderIdResponse.orderId(),
+                accessToken)
+            .as(DetailOrderResponse.class);
+
+        assertThat(productResponse.quantity()).isEqualTo(10);
+        assertThat(orderResponse.type()).isEqualTo("PENDING");
+    }
+
+    @Test
+    @DisplayName("결제 실패 후, 재결재를 하면, Product quantity가 줄어들고, Order의 상태가 SUCCESS로 변경된다")
+    void decreaseProductQuantityWhenPayReSuccess() {
+        // given
+        final long productId = getRandomProduct(accessToken).productId();
+        final int quantity = 2;
+        final OrderProductQuantityRequest orderProductRequest = new OrderProductQuantityRequest(
+            quantity);
+        final OrderIdResponse orderIdResponse = OrderApiSupporter.orderProduct(productId,
+            orderProductRequest,
+            accessToken).as(OrderIdResponse.class);
+
+        final PayRequest payFailRequest = new PayRequest("CARD", false);
+        final PayRequest paySuccessRequest = new PayRequest("CARD", true);
+
+        // when
+        PayApiSupporter.pay(payFailRequest, orderIdResponse.orderId(), accessToken);
+        PayApiSupporter.pay(paySuccessRequest, orderIdResponse.orderId(), accessToken);
+
+        // then
+        final ProductDetailsResponse productResponse = ShopApiSupporter.getProduct(productId)
+            .as(ProductDetailsResponse.class);
+        final DetailOrderResponse orderResponse = OrderApiSupporter.getOrderByOrderId(orderIdResponse.orderId(),
+                accessToken)
+            .as(DetailOrderResponse.class);
+
+        assertThat(productResponse.quantity()).isEqualTo(8);
+        assertThat(orderResponse.type()).isEqualTo("SUCCESS");
+    }
+
+    private ProductResponse getRandomProduct(final String accessToken) {
+        ShopApiSupporter.registerProduct(accessToken, ProductFixture.registerValidProductRequest());
+
+        return ShopApiSupporter.getAllProducts().as(ProductsResponse.class)
+            .products().get(0);
+    }
+
+}

--- a/app/src/test/java/shop/woowasap/accept/support/api/PayApiSupporter.java
+++ b/app/src/test/java/shop/woowasap/accept/support/api/PayApiSupporter.java
@@ -1,0 +1,32 @@
+package shop.woowasap.accept.support.api;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpHeaders;
+import shop.woowasap.payment.controller.request.PayRequest;
+
+public final class PayApiSupporter {
+
+    private static final String API_VERSION = "v1";
+
+    private PayApiSupporter() {
+        throw new UnsupportedOperationException(
+            "Cannot invoke constructor \"PayApiSupporter()\"");
+    }
+
+    public static ExtractableResponse<Response> pay(final PayRequest request, final long orderId, final String token) {
+
+        return given().log().all()
+            .contentType(JSON)
+            .accept(JSON)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .body(request)
+            .when().log().all()
+            .post(API_VERSION + "/pays/{order-id}", orderId)
+            .then().log().all()
+            .extract();
+    }
+}

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/DetailOrderResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/DetailOrderResponse.java
@@ -4,6 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record DetailOrderResponse(long orderId, List<DetailOrderProductResponse> products,
-                                  String totalPrice, LocalDateTime createdAt) {
+                                  String totalPrice, String type, LocalDateTime createdAt) {
 
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderEventService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderEventService.java
@@ -68,7 +68,6 @@ public class OrderEventService implements OrderEventConsumer {
     }
 
     private void persistOrderType(final Order order, final OrderType orderType) {
-        order.updateOrderType(orderType);
-        orderRepository.persist(order);
+        orderRepository.persist(order.updateOrderType(orderType));
     }
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
@@ -85,7 +85,7 @@ public final class OrderMapper {
         final List<DetailOrderProductResponse> detailOrderProductResponses, final String locale) {
 
         return new DetailOrderResponse(order.getId(), detailOrderProductResponses,
-            order.getTotalPrice().toString(),
+            order.getTotalPrice().toString(), order.getOrderType().toString(),
             LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
     }
 

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import shop.woowasap.order.domain.Order;
+import shop.woowasap.order.domain.OrderType;
 import shop.woowasap.order.domain.in.response.DetailOrderProductResponse;
 import shop.woowasap.order.domain.in.response.DetailOrderResponse;
 import shop.woowasap.order.domain.in.response.OrderProductResponse;
@@ -54,6 +55,6 @@ public final class OrderDtoFixture {
             .toList();
 
         return new DetailOrderResponse(order.getId(), detailOrderProductResponses, order.getTotalPrice().toString(),
-            LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
+            OrderType.PENDING.toString(), LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
     }
 }

--- a/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/PaymentRepositoryImpl.java
+++ b/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/PaymentRepositoryImpl.java
@@ -23,7 +23,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
 
     @Override
     public List<Payment> findAllByOrderId(final long orderId) {
-        final List<PaymentEntity> result = paymentEntityRepository.findByOrderIdOrdOrderByUpdatedAtDesc(
+        final List<PaymentEntity> result = paymentEntityRepository.findByOrderIdOrderByUpdatedAtDesc(
             orderId);
         return result.stream().map(PaymentEntityMapper::toDomain).toList();
     }

--- a/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/jpa/PaymentEntityRepository.java
+++ b/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/jpa/PaymentEntityRepository.java
@@ -6,5 +6,5 @@ import shop.woowasap.payment.repository.entity.PaymentEntity;
 
 public interface PaymentEntityRepository extends JpaRepository<PaymentEntity, Long> {
 
-    List<PaymentEntity> findByOrderIdOrdOrderByUpdatedAtDesc(final long orderId);
+    List<PaymentEntity> findByOrderIdOrderByUpdatedAtDesc(final long orderId);
 }

--- a/payment/payment-repository/src/test/java/shop/woowasap/payment/repository/PaymentRepositoryImplTest.java
+++ b/payment/payment-repository/src/test/java/shop/woowasap/payment/repository/PaymentRepositoryImplTest.java
@@ -84,7 +84,7 @@ class PaymentRepositoryImplTest {
                 .build();
             final PaymentEntity entity = PaymentEntityMapper.toEntity(payment);
 
-            when(paymentEntityRepository.findByOrderIdOrdOrderByUpdatedAtDesc(12L)).thenReturn(
+            when(paymentEntityRepository.findByOrderIdOrderByUpdatedAtDesc(12L)).thenReturn(
                 List.of(entity));
 
             // when


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
주문 - 결제 검증 테스트를 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 주문 - 결제 검증 테스트 추가
- [x] DetailOrderResponse에서 주문의 상태를 반환하도록 수정

## 🦀 이슈 넘버
- close #212 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
