### PR TITLE
feat: `Async thread, wait queue` count 설정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,5 +24,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
     testImplementation 'io.rest-assured:rest-assured:5.3.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
     runtimeOnly 'com.h2database:h2'
 }

--- a/coverage-exclude.asap
+++ b/coverage-exclude.asap
@@ -13,3 +13,4 @@ exclude shop/woowasap/*/repository/entity/*
 exclude shop/woowasap/payment/domain/*
 exclude shop/woowasap/core/util/time/*
 exclude shop/woowasap/*/domain/*/event/*
+exclude shop/woowasap/*/service/config/*

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderEventService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderEventService.java
@@ -16,6 +16,7 @@ import shop.woowasap.order.domain.in.event.PaySuccessEvent;
 import shop.woowasap.order.domain.out.OrderRepository;
 import shop.woowasap.order.domain.out.event.StockFailEvent;
 import shop.woowasap.order.domain.out.event.StockSuccessEvent;
+import shop.woowasap.order.service.config.OrderAsyncConfig;
 import shop.woowasap.shop.domain.in.product.ProductConnector;
 
 @Service
@@ -27,8 +28,8 @@ public class OrderEventService implements OrderEventConsumer {
     private final ProductConnector productConnector;
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @Async
     @Override
+    @Async(OrderAsyncConfig.PAY_FAIL)
     @EventListener(PayFailEvent.class)
     public void listenPayFailEvent(final PayFailEvent payFailEvent) {
         final Order order = getOrder(payFailEvent.orderId(), payFailEvent.userId());
@@ -36,8 +37,8 @@ public class OrderEventService implements OrderEventConsumer {
         persistOrderType(order, OrderType.FAIL);
     }
 
-    @Async
     @Override
+    @Async(OrderAsyncConfig.PAY_SUCCESS)
     @EventListener(PaySuccessEvent.class)
     public void listenPaySuccessEvent(final PaySuccessEvent paySuccessEvent) {
         final Order order = getOrder(paySuccessEvent.orderId(), paySuccessEvent.userId());

--- a/order/order-service/src/main/java/shop/woowasap/order/service/config/OrderAsyncConfig.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/config/OrderAsyncConfig.java
@@ -1,0 +1,39 @@
+package shop.woowasap.order.service.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class OrderAsyncConfig {
+
+    public static final String PAY_FAIL = "payFailEventExecutor";
+    public static final String PAY_SUCCESS = "paySuccessEventExecutor";
+
+
+    @Bean(PAY_FAIL)
+    public Executor payFailEventExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix(PAY_FAIL);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(PAY_SUCCESS)
+    public Executor paySuccessEventExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix(PAY_SUCCESS);
+        executor.initialize();
+        return executor;
+    }
+}
+

--- a/payment/payment-service/src/main/java/shop/woowasap/payment/service/PaymentEventService.java
+++ b/payment/payment-service/src/main/java/shop/woowasap/payment/service/PaymentEventService.java
@@ -12,6 +12,7 @@ import shop.woowasap.payment.domain.PayStatus;
 import shop.woowasap.payment.domain.Payment;
 import shop.woowasap.payment.domain.exception.DoesNotFindPaymentException;
 import shop.woowasap.payment.domain.out.PaymentRepository;
+import shop.woowasap.payment.service.config.PaymentAsyncConfig;
 
 @Service
 @RequiredArgsConstructor
@@ -20,9 +21,9 @@ public class PaymentEventService {
 
     private final PaymentRepository paymentRepository;
 
-    @Async
     @Transactional
     @EventListener(StockSuccessEvent.class)
+    @Async(PaymentAsyncConfig.STOCK_SUCCESS)
     public void successPayment(final StockSuccessEvent stockSuccessEvent) {
         final List<Payment> payments = paymentRepository.findAllByOrderId(
             stockSuccessEvent.orderId());
@@ -33,9 +34,9 @@ public class PaymentEventService {
         paymentRepository.save(payment.changeStatus(PayStatus.SUCCESS));
     }
 
-    @Async
     @Transactional
     @EventListener(StockFailEvent.class)
+    @Async(PaymentAsyncConfig.STOCK_FAIL)
     public void cancelPayment(final StockFailEvent stockFailEvent) {
         final List<Payment> payments = paymentRepository.findAllByOrderId(
             stockFailEvent.orderId());

--- a/payment/payment-service/src/main/java/shop/woowasap/payment/service/config/PaymentAsyncConfig.java
+++ b/payment/payment-service/src/main/java/shop/woowasap/payment/service/config/PaymentAsyncConfig.java
@@ -1,0 +1,39 @@
+package shop.woowasap.payment.service.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class PaymentAsyncConfig {
+
+    public static final String STOCK_FAIL = "stockFailEventExecutor";
+    public static final String STOCK_SUCCESS = "stockSuccessEventExecutor";
+
+
+    @Bean(STOCK_FAIL)
+    public Executor stockFailEventExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix(STOCK_FAIL);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(STOCK_SUCCESS)
+    public Executor stockSuccessEventExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix(STOCK_SUCCESS);
+        executor.initialize();
+        return executor;
+    }
+}
+


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
`Async thread, wait queue` count를 설정 했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 기본 thread 수 1개로 설정
- [x] 최대 thread 수 10개로 설정
- [x] 최대 대기열 queue 100개로 설정
- [x] 인수테스트에 비동기로직 대기 시간, 상태 설정

## 🦀 이슈 넘버
- close #214 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
