### PR TITLE
feat: `ErrorTemplate`, `ControllerAdvice` 를 부착

### DIFF
--- a/app/src/main/java/shop/woowasap/advice/GlobalExceptionHandler.java
+++ b/app/src/main/java/shop/woowasap/advice/GlobalExceptionHandler.java
@@ -5,14 +5,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import shop.woowasap.core.util.web.ErrorTemplate;
 
 @Slf4j
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    ResponseEntity<Void> handleException(final Exception exception) {
+    ResponseEntity<ErrorTemplate> handleException(final Exception exception) {
         log.error(exception.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorTemplate.of(exception.getMessage()));
     }
 }

--- a/auth/auth-controller/build.gradle
+++ b/auth/auth-controller/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':core:util')
     implementation project(':auth:auth-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/auth/auth-controller/src/main/java/shop/woowasap/auth/controller/AuthController.java
+++ b/auth/auth-controller/src/main/java/shop/woowasap/auth/controller/AuthController.java
@@ -17,6 +17,7 @@ import shop.woowasap.auth.domain.exception.DuplicatedUsernameException;
 import shop.woowasap.auth.domain.in.UserUseCase;
 import shop.woowasap.auth.domain.in.request.UserCreateRequest;
 import shop.woowasap.auth.domain.in.response.LoginResponse;
+import shop.woowasap.core.util.web.ErrorTemplate;
 
 @RestController
 @RequestMapping("/v1")
@@ -42,22 +43,23 @@ public class AuthController {
     }
 
     @ExceptionHandler(DuplicatedUsernameException.class)
-    public ResponseEntity<String> handleAuthExceptions(
+    public ResponseEntity<ErrorTemplate> handleAuthExceptions(
         final DuplicatedUsernameException duplicatedUsernameException) {
 
         return ResponseEntity.status(HttpStatus.CONFLICT)
-            .body(duplicatedUsernameException.getMessage());
+            .body(ErrorTemplate.of(duplicatedUsernameException.getMessage()));
     }
 
     @ExceptionHandler(AuthDomainBaseException.class)
-    public ResponseEntity<String> handleAuthExceptions(
+    public ResponseEntity<ErrorTemplate> handleAuthExceptions(
         final AuthDomainBaseException authDomainBaseException) {
 
-        return ResponseEntity.badRequest().body(authDomainBaseException.getMessage());
+        return ResponseEntity.badRequest()
+            .body(ErrorTemplate.of(authDomainBaseException.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleMethodArgumentNotValidException(
+    public ResponseEntity<ErrorTemplate> handleMethodArgumentNotValidException(
         final MethodArgumentNotValidException methodArgumentNotValidException) {
 
         String defaultMessage = methodArgumentNotValidException
@@ -68,6 +70,6 @@ public class AuthController {
             .orElseThrow()
             .getDefaultMessage();
         return ResponseEntity.badRequest()
-            .body(defaultMessage);
+            .body(ErrorTemplate.of(defaultMessage));
     }
 }

--- a/core/util/src/main/java/shop/woowasap/core/util/web/ErrorTemplate.java
+++ b/core/util/src/main/java/shop/woowasap/core/util/web/ErrorTemplate.java
@@ -1,0 +1,18 @@
+package shop.woowasap.core.util.web;
+
+public final class ErrorTemplate {
+
+    private final String message;
+
+    private ErrorTemplate(final String message) {
+        this.message = message;
+    }
+
+    public static ErrorTemplate of(final String message) {
+        return new ErrorTemplate(message);
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/coverage-exclude.asap
+++ b/coverage-exclude.asap
@@ -14,3 +14,4 @@ exclude shop/woowasap/payment/domain/*
 exclude shop/woowasap/core/util/time/*
 exclude shop/woowasap/*/domain/*/event/*
 exclude shop/woowasap/*/service/config/*
+exclude shop/woowasap/advice/GlobalExceptionHandler

--- a/order/order-controller/build.gradle
+++ b/order/order-controller/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    implementation project(':order:order-domain')
+    implementation project(':core:util')
     implementation project(':auth:auth-domain')
+    implementation project(':order:order-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.auth.domain.in.LoginUser;
+import shop.woowasap.core.util.web.ErrorTemplate;
 import shop.woowasap.order.controller.request.OrderProductQuantityRequest;
 import shop.woowasap.order.domain.exception.DoesNotFindCartException;
 import shop.woowasap.order.domain.exception.DoesNotFindOrderException;
@@ -82,7 +83,8 @@ public class OrderController {
         InvalidQuantityException.class,
         DoesNotFindOrderException.class,
         DoesNotFindCartException.class})
-    private ResponseEntity<Void> handleBadRequest() {
-        return ResponseEntity.badRequest().build();
+    private ResponseEntity<ErrorTemplate> handleBadRequest(final Exception exception) {
+        return ResponseEntity.badRequest()
+            .body(ErrorTemplate.of(exception.getMessage()));
     }
 }

--- a/payment/payment-controller/build.gradle
+++ b/payment/payment-controller/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    implementation project(':payment:payment-domain')
+    implementation project(':core:util')
     implementation project(':auth:auth-domain')
+    implementation project(':payment:payment-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/payment/payment-controller/src/main/java/shop/woowasap/payment/controller/PayController.java
+++ b/payment/payment-controller/src/main/java/shop/woowasap/payment/controller/PayController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.auth.domain.in.LoginUser;
+import shop.woowasap.core.util.web.ErrorTemplate;
 import shop.woowasap.payment.controller.request.PayRequest;
 import shop.woowasap.payment.domain.PayType;
 import shop.woowasap.payment.domain.exception.DoesNotFindOrderException;
@@ -46,12 +47,14 @@ public class PayController {
         MethodArgumentNotValidException.class,
         IllegalArgumentException.class
     })
-    public ResponseEntity<String> handleBadRequest(Exception e) {
-        return ResponseEntity.badRequest().body(e.getMessage());
+    public ResponseEntity<ErrorTemplate> handleBadRequest(final Exception exception) {
+        return ResponseEntity.badRequest()
+            .body(ErrorTemplate.of(exception.getMessage()));
     }
 
     @ExceptionHandler(value = PayUserNotMatchException.class)
-    public ResponseEntity<String> handleForbidden(Exception e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    public ResponseEntity<ErrorTemplate> handleForbidden(Exception exception) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(ErrorTemplate.of(exception.getMessage()));
     }
 }

--- a/shop/shop-controller/build.gradle
+++ b/shop/shop-controller/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':core:util')
     implementation project(':shop:shop-domain')
     implementation project(':auth:auth-domain')
 

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import shop.woowasap.core.util.web.ErrorTemplate;
 import shop.woowasap.shop.domain.in.cart.CartUseCase;
 import shop.woowasap.shop.domain.in.cart.request.AddCartProductRequest;
 import shop.woowasap.shop.domain.in.cart.request.UpdateCartProductRequest;
@@ -58,7 +59,8 @@ public class CartController {
     }
 
     @ExceptionHandler({NotExistsCartProductException.class, NotExistsProductException.class})
-    public ResponseEntity<Void> handleException() {
-        return ResponseEntity.badRequest().build();
+    public ResponseEntity<ErrorTemplate> handleException(final Exception exception) {
+        return ResponseEntity.badRequest()
+            .body(ErrorTemplate.of(exception.getMessage()));
     }
 }

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import shop.woowasap.core.util.web.ErrorTemplate;
+import shop.woowasap.shop.domain.exception.ProductException;
 import shop.woowasap.shop.domain.in.product.ProductUseCase;
 import shop.woowasap.shop.domain.in.product.request.RegisterProductRequest;
 import shop.woowasap.shop.domain.in.product.request.UpdateProductRequest;
@@ -60,8 +62,9 @@ public class ProductAdminController {
         return ResponseEntity.ok(productResponse);
     }
 
-    @ExceptionHandler(NotExistsProductException.class)
-    public ResponseEntity<Void> handleException() {
-        return ResponseEntity.badRequest().build();
+    @ExceptionHandler(ProductException.class)
+    public ResponseEntity<ErrorTemplate> handleException(final ProductException productException) {
+        return ResponseEntity.badRequest()
+            .body(ErrorTemplate.of(productException.getMessage()));
     }
 }

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import shop.woowasap.core.util.web.ErrorTemplate;
 import shop.woowasap.shop.domain.exception.NotExistsProductException;
+import shop.woowasap.shop.domain.exception.ProductException;
 import shop.woowasap.shop.domain.in.product.ProductUseCase;
 import shop.woowasap.shop.domain.in.product.response.ProductDetailsResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductsResponse;
@@ -34,9 +36,10 @@ public class ProductController {
         return ResponseEntity.ok(productUseCase.getValidProducts(page, size));
     }
 
-    @ExceptionHandler(NotExistsProductException.class)
-    public ResponseEntity<Void> handleException() {
-        return ResponseEntity.badRequest().build();
+    @ExceptionHandler(ProductException.class)
+    public ResponseEntity<ErrorTemplate> handleException(final ProductException productException) {
+        return ResponseEntity.badRequest()
+            .body(ErrorTemplate.of(productException.getMessage()));
     }
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
ErrorTemplate과 ControllerAdvice 를 부착 했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] ErrorTemplate을 만들고, ControllerAdvice에서 반환하도록 함
- [x] ProductController, ProductAdminController에서 상세한 예외를 반환하도록 수정

## 🦀 이슈 넘버
- close #235 
- close #238 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
