### PR TITLE
chore: `4xx` 번 예외 info 로그 남기게 설정

### DIFF
--- a/app/src/main/resources/logback-spring.xml
+++ b/app/src/main/resources/logback-spring.xml
@@ -10,20 +10,47 @@
   <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
   <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     <options>
-      <dsn>https://c3c1572293ee46d8b7d48d2b1372a910@o4505740223578112.ingest.sentry.io/4505740339249152</dsn>
+      <dsn>
+        https://c3c1572293ee46d8b7d48d2b1372a910@o4505740223578112.ingest.sentry.io/4505740339249152
+      </dsn>
     </options>
+  </appender>
+
+  <appender name="File" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>info</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+
+    <file>./logs/logs.log</file>
+
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>./logs/logs.%d{yyyy-MM-dd}_%i.log.zip</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy
+        class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>10MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+    </rollingPolicy>
   </appender>
 
   <!-- Enable the Console and Sentry appenders, Console is provided as an example
   of a non-Sentry logger that is set to a different logging threshold -->
   <root level="INFO">
-    <appender-ref ref="Console" />
-    <appender-ref ref="Sentry" />
+    <appender-ref ref="Console"/>
+    <appender-ref ref="File"/>
+    <appender-ref ref="Sentry"/>
   </root>
 
   <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     <options>
-      <dsn>https://c3c1572293ee46d8b7d48d2b1372a910@o4505740223578112.ingest.sentry.io/4505740339249152</dsn>
+      <dsn>
+        https://c3c1572293ee46d8b7d48d2b1372a910@o4505740223578112.ingest.sentry.io/4505740339249152
+      </dsn>
     </options>
     <!-- Optionally change minimum Event level. Default for Events is ERROR -->
     <minimumEventLevel>WARN</minimumEventLevel>

--- a/auth/auth-controller/src/main/java/shop/woowasap/auth/controller/AuthController.java
+++ b/auth/auth-controller/src/main/java/shop/woowasap/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package shop.woowasap.auth.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -19,6 +20,7 @@ import shop.woowasap.auth.domain.in.request.UserCreateRequest;
 import shop.woowasap.auth.domain.in.response.LoginResponse;
 import shop.woowasap.core.util.web.ErrorTemplate;
 
+@Slf4j
 @RestController
 @RequestMapping("/v1")
 @RequiredArgsConstructor
@@ -45,6 +47,7 @@ public class AuthController {
     @ExceptionHandler(DuplicatedUsernameException.class)
     public ResponseEntity<ErrorTemplate> handleAuthExceptions(
         final DuplicatedUsernameException duplicatedUsernameException) {
+        log.info(duplicatedUsernameException.getMessage());
 
         return ResponseEntity.status(HttpStatus.CONFLICT)
             .body(ErrorTemplate.of(duplicatedUsernameException.getMessage()));
@@ -53,6 +56,7 @@ public class AuthController {
     @ExceptionHandler(AuthDomainBaseException.class)
     public ResponseEntity<ErrorTemplate> handleAuthExceptions(
         final AuthDomainBaseException authDomainBaseException) {
+        log.info(authDomainBaseException.getMessage());
 
         return ResponseEntity.badRequest()
             .body(ErrorTemplate.of(authDomainBaseException.getMessage()));
@@ -61,6 +65,7 @@ public class AuthController {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorTemplate> handleMethodArgumentNotValidException(
         final MethodArgumentNotValidException methodArgumentNotValidException) {
+        log.info(methodArgumentNotValidException.getMessage());
 
         String defaultMessage = methodArgumentNotValidException
             .getBindingResult()

--- a/coverage-exclude.asap
+++ b/coverage-exclude.asap
@@ -11,7 +11,7 @@ exclude shop/woowasap/auth/infra/*/*
 exclude shop/woowasap/order/payment/random/RandomOrderPayment
 exclude shop/woowasap/*/repository/entity/*
 exclude shop/woowasap/payment/domain/*
-exclude shop/woowasap/core/util/time/*
+exclude shop/woowasap/core/util/*/*
 exclude shop/woowasap/*/domain/*/event/*
 exclude shop/woowasap/*/service/config/*
 exclude shop/woowasap/advice/GlobalExceptionHandler

--- a/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
+++ b/order/order-controller/src/main/java/shop/woowasap/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package shop.woowasap.order.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +28,7 @@ import shop.woowasap.order.domain.in.response.DetailOrderResponse;
 import shop.woowasap.order.domain.in.response.OrderIdResponse;
 import shop.woowasap.order.domain.in.response.OrdersResponse;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/orders")
@@ -84,6 +86,8 @@ public class OrderController {
         DoesNotFindOrderException.class,
         DoesNotFindCartException.class})
     private ResponseEntity<ErrorTemplate> handleBadRequest(final Exception exception) {
+        log.info(exception.getMessage());
+
         return ResponseEntity.badRequest()
             .body(ErrorTemplate.of(exception.getMessage()));
     }

--- a/payment/payment-controller/src/main/java/shop/woowasap/payment/controller/PayController.java
+++ b/payment/payment-controller/src/main/java/shop/woowasap/payment/controller/PayController.java
@@ -2,6 +2,7 @@ package shop.woowasap.payment.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -23,6 +24,7 @@ import shop.woowasap.payment.domain.in.PaymentUseCase;
 import shop.woowasap.payment.domain.in.request.PaymentRequest;
 import shop.woowasap.payment.domain.in.response.PaymentResponse;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/pays")
@@ -48,12 +50,16 @@ public class PayController {
         IllegalArgumentException.class
     })
     public ResponseEntity<ErrorTemplate> handleBadRequest(final Exception exception) {
+        log.info(exception.getMessage());
+
         return ResponseEntity.badRequest()
             .body(ErrorTemplate.of(exception.getMessage()));
     }
 
     @ExceptionHandler(value = PayUserNotMatchException.class)
-    public ResponseEntity<ErrorTemplate> handleForbidden(Exception exception) {
+    public ResponseEntity<ErrorTemplate> handleForbidden(final Exception exception) {
+        log.info(exception.getMessage());
+
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
             .body(ErrorTemplate.of(exception.getMessage()));
     }

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/CartController.java
@@ -1,6 +1,7 @@
 package shop.woowasap.shop.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -20,6 +21,7 @@ import shop.woowasap.shop.domain.exception.NotExistsProductException;
 import shop.woowasap.shop.domain.exception.NotExistsCartProductException;
 import shop.woowasap.auth.domain.in.LoginUser;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/carts")
@@ -60,6 +62,8 @@ public class CartController {
 
     @ExceptionHandler({NotExistsCartProductException.class, NotExistsProductException.class})
     public ResponseEntity<ErrorTemplate> handleException(final Exception exception) {
+        log.info(exception.getMessage());
+
         return ResponseEntity.badRequest()
             .body(ErrorTemplate.of(exception.getMessage()));
     }

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductAdminController.java
@@ -2,6 +2,7 @@ package shop.woowasap.shop.controller;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,8 +20,8 @@ import shop.woowasap.shop.domain.in.product.request.RegisterProductRequest;
 import shop.woowasap.shop.domain.in.product.request.UpdateProductRequest;
 import shop.woowasap.shop.domain.in.product.response.ProductDetailsResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductsResponse;
-import shop.woowasap.shop.domain.exception.NotExistsProductException;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/admin/products")
@@ -64,6 +65,8 @@ public class ProductAdminController {
 
     @ExceptionHandler(ProductException.class)
     public ResponseEntity<ErrorTemplate> handleException(final ProductException productException) {
+        log.info(productException.getMessage());
+
         return ResponseEntity.badRequest()
             .body(ErrorTemplate.of(productException.getMessage()));
     }

--- a/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductController.java
+++ b/shop/shop-controller/src/main/java/shop/woowasap/shop/controller/ProductController.java
@@ -1,6 +1,7 @@
 package shop.woowasap.shop.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,12 +10,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.woowasap.core.util.web.ErrorTemplate;
-import shop.woowasap.shop.domain.exception.NotExistsProductException;
 import shop.woowasap.shop.domain.exception.ProductException;
 import shop.woowasap.shop.domain.in.product.ProductUseCase;
 import shop.woowasap.shop.domain.in.product.response.ProductDetailsResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductsResponse;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/products")
@@ -38,6 +39,8 @@ public class ProductController {
 
     @ExceptionHandler(ProductException.class)
     public ResponseEntity<ErrorTemplate> handleException(final ProductException productException) {
+        log.info(productException.getMessage());
+
         return ResponseEntity.badRequest()
             .body(ErrorTemplate.of(productException.getMessage()));
     }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
`4xx` 번 예외에 대해서, info 로그를 남기도록 설정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `4xx` 번 예외에 대해서 info 로그를 남기도록 `@RestControllerAdvice` 를 부착함.
- [x] `logback-spring` 에 `4xx` 번 예외 파일로 남기도록 설정

## 🦀 이슈 넘버
- close #236

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
