### PR TITLE
feat: 상품 판매 시간 변경

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/product/SaleTime.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/product/SaleTime.java
@@ -18,7 +18,7 @@ public class SaleTime {
 
     public static final int MIN_DIFF_NOW_AND_START_SECOND = 60 * 10;
     public static final int MIN_SALE_DURATION_HOUR = 1;
-    public static final int MAX_SALE_DURATION_HOUR = 12;
+    public static final int MAX_SALE_DURATION_HOUR = 24 * 10;
     public static final int SECONDS_OF_HOUR = 60 * 60;
 
     private final Instant startTime;

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/ProductTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/ProductTest.java
@@ -182,11 +182,11 @@ class ProductTest {
         }
 
         @Test
-        @DisplayName("판매 시간이 12시간을 초과하는 경우, InvalidProductSaleDurationException 반환한다.")
+        @DisplayName("판매 시간이 10일을 초과하는 경우, InvalidProductSaleDurationException 반환한다.")
         void throwExceptionWhenDurationIsOver12Hour() {
             // given
             final Instant startTime = Instant.parse("2023-08-05T20:00:00.000Z");
-            final Instant endTime = Instant.parse("2023-08-07T20:00:00.000Z");
+            final Instant endTime = Instant.parse("2023-08-20T20:00:00.000Z");
             final Instant nowTime = Instant.parse("2023-08-01T00:00:00.000Z");
 
             // when

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/SaleTimeTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/SaleTimeTest.java
@@ -95,11 +95,11 @@ public class SaleTimeTest {
         }
 
         @Test
-        @DisplayName("endTime - startTime 이 12시간를 초과한다면 InvalidProductSaleDurationException 를 던진다.")
+        @DisplayName("endTime - startTime 이 10일을 초과한다면 InvalidProductSaleDurationException 를 던진다.")
         void throwExceptionSaleTimeIsOver12Hour() {
             // given
             final Instant startTime = Instant.parse("2023-08-05T20:00:00.000Z");
-            final Instant endTime = Instant.parse("2023-08-07T20:00:00.000Z");
+            final Instant endTime = Instant.parse("2023-08-20T20:00:00.000Z");
             final Instant nowTime = Instant.parse("2023-08-01T20:00:00.000Z");
 
             // when

--- a/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/support/ProductFixture.java
+++ b/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/support/ProductFixture.java
@@ -1,6 +1,5 @@
 package shop.woowasap.shop.repository.support;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import shop.woowasap.shop.domain.product.Product;
@@ -22,14 +21,11 @@ public class ProductFixture {
     public static final LocalDateTime BEFORE_SALE_START_TIME = LocalDateTime.of(2023, 8, 2, 0, 0);
     public static final LocalDateTime BEFORE_SALE_END_TIME = LocalDateTime.of(2023, 8, 2, 1, 0);
 
-    private static final Instant BEFORE_ALL_TIME = Instant.parse("2022-08-01T00:00:00.000Z");
-
     public static Product beforeSaleProduct(final Long id) {
 
         final SaleTime saleTime = SaleTime.builder()
             .startTime(BEFORE_SALE_START_TIME.toInstant(ZoneOffset.UTC))
             .endTime(BEFORE_SALE_END_TIME.toInstant(ZoneOffset.UTC))
-            .nowTime(BEFORE_ALL_TIME)
             .build();
 
         return Product.builder()
@@ -46,7 +42,6 @@ public class ProductFixture {
         final SaleTime saleTime = SaleTime.builder()
             .startTime(ON_SALE_START_TIME.toInstant(ZoneOffset.UTC))
             .endTime(ON_SALE_END_TIME.toInstant(ZoneOffset.UTC))
-            .nowTime(BEFORE_ALL_TIME)
             .build();
 
         return Product.builder()
@@ -63,7 +58,6 @@ public class ProductFixture {
         final SaleTime saleTime = SaleTime.builder()
             .startTime(ON_SALE_START_TIME.toInstant(ZoneOffset.UTC))
             .endTime(ON_SALE_END_TIME.toInstant(ZoneOffset.UTC))
-            .nowTime(BEFORE_ALL_TIME)
             .build();
 
         return Product.builder()
@@ -80,7 +74,6 @@ public class ProductFixture {
         final SaleTime saleTime = SaleTime.builder()
             .startTime(AFTER_SALE_START_TIME.toInstant(ZoneOffset.UTC))
             .endTime(AFTER_SALE_END_TIME.toInstant(ZoneOffset.UTC))
-            .nowTime(BEFORE_ALL_TIME)
             .build();
 
         return Product.builder()

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductServiceTest.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductServiceTest.java
@@ -45,6 +45,8 @@ import shop.woowasap.shop.service.support.fixture.ProductFixture;
 @ContextConfiguration(classes = ProductService.class)
 class ProductServiceTest {
 
+    private static final Instant NOW_TIME = Instant.parse("2023-08-01T01:00:00.000Z");
+
     @Autowired
     private ProductService productService;
 
@@ -59,7 +61,7 @@ class ProductServiceTest {
 
     @BeforeEach
     void setUpTime() {
-        when(timeUtil.now()).thenReturn(Instant.parse("2023-08-01T01:00:00.000Z"));
+        when(timeUtil.now()).thenReturn(NOW_TIME);
     }
 
     @Nested
@@ -242,11 +244,9 @@ class ProductServiceTest {
             Product product1 = beforeSaleProduct(1L);
             Product product2 = beforeSaleProduct(2L);
 
-            final Instant nowTime = Instant.parse("2023-08-01T01:00:00.000Z");
-
             List<Product> products = List.of(product1, product2);
 
-            when(productRepository.findAllValidWithPagination(page, pageSize, nowTime)).thenReturn(
+            when(productRepository.findAllValidWithPagination(page, pageSize, NOW_TIME)).thenReturn(
                 new ProductsPaginationResponse(products, page, totalPage));
 
             // when

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/support/fixture/ProductFixture.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/support/fixture/ProductFixture.java
@@ -1,6 +1,5 @@
 package shop.woowasap.shop.service.support.fixture;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -31,9 +30,6 @@ public class ProductFixture {
 
     public static final LocalDateTime BEFORE_SALE_START_TIME = LocalDateTime.of(2023, 8, 2, 0, 0);
     public static final LocalDateTime BEFORE_SALE_END_TIME = LocalDateTime.of(2023, 8, 2, 1, 0);
-
-    private static final Instant BEFORE_ALL_TIME = Instant.parse("2022-08-01T00:00:00.000Z");
-    private static final Instant NOW_TIME = Instant.parse("2023-08-01T00:00:00.000Z");
 
     public static Product.ProductBuilder onSaleProductBuilder(final Long id) {
         final SaleTime saleTime = SaleTime.builder()
@@ -70,7 +66,6 @@ public class ProductFixture {
         final SaleTime saleTime = SaleTime.builder()
             .startTime(BEFORE_SALE_START_TIME.toInstant(ZoneOffset.UTC))
             .endTime(BEFORE_SALE_END_TIME.toInstant(ZoneOffset.UTC))
-            .nowTime(NOW_TIME)
             .build();
 
         return Product.builder()
@@ -88,7 +83,6 @@ public class ProductFixture {
         final SaleTime saleTime = SaleTime.builder()
             .startTime(ON_SALE_START_TIME.toInstant(ZoneOffset.UTC))
             .endTime(ON_SALE_END_TIME.toInstant(ZoneOffset.UTC))
-            .nowTime(BEFORE_ALL_TIME)
             .build();
 
         return Product.builder()
@@ -106,7 +100,6 @@ public class ProductFixture {
         final SaleTime saleTime = SaleTime.builder()
             .startTime(AFTER_SALE_START_TIME.toInstant(ZoneOffset.UTC))
             .endTime(AFTER_SALE_END_TIME.toInstant(ZoneOffset.UTC))
-            .nowTime(BEFORE_ALL_TIME)
             .build();
 
         return Product.builder()


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 상품 판매 시간을 최대 12시간에서 최대 10일로 변경했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] SaleTime의 검증 로직에 사용되는 시간 상수 수정
- [x] 불필요한 시간 상수 제거 

## 🦀 이슈 넘버
- close #242
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
