### PR TITLE
feat: `Order` , `Pay` Cancel 서비스를 구현한다

### DIFF
--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/OrderUseCase.java
@@ -14,4 +14,6 @@ public interface OrderUseCase {
     OrdersResponse getOrderByUserId(final long userId, final int page, final int size);
 
     DetailOrderResponse getOrderByOrderIdAndUserId(final long orderId, final long userId);
+
+    void cancelOrder(final long orderId, final long userId);
 }

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/out/event/OrderCanceledEvent.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/out/event/OrderCanceledEvent.java
@@ -1,0 +1,5 @@
+package shop.woowasap.order.domain.out.event;
+
+public record OrderCanceledEvent(long orderId) {
+
+}

--- a/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/OrderServiceTest.java
@@ -267,4 +267,49 @@ class OrderServiceTest {
             assertThat(result).isInstanceOf(DoesNotFindOrderException.class);
         }
     }
+
+    @Nested
+    @DisplayName("cancelOrder 메소드는")
+    class cancelOrderMethod {
+
+        @Test
+        @DisplayName("orderId와 userId를 받아, 주문을 취소한다.")
+        void cancelOrderWhenReceiveOrderIdAndUserId() {
+            // given
+            final long orderId = 1L;
+            final long userId = 1L;
+
+            final Product product = ProductFixture.getDefaultBuilder().build();
+            final OrderProduct orderProduct = OrderProductFixture.from(product);
+            final Order defaultOrder = OrderFixture.getDefault(List.of(orderProduct));
+
+            when(orderRepository.findOrderByOrderIdAndUserId(orderId, userId)).thenReturn(
+                Optional.of(defaultOrder));
+
+            // when
+            final Exception result = catchException(
+                () -> orderUseCase.cancelOrder(orderId, userId));
+
+            // then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("orderId와 userId에 해당하는 Order가 없을경우, DoesNotFindOrderException 를 던진다.")
+        void throwDoesNotFindOrderExceptionIfOrderNotExist() {
+            // given
+            final long orderId = 1L;
+            final long userId = 1L;
+
+            when(orderRepository.findOrderByOrderIdAndUserId(orderId, userId)).thenReturn(
+                Optional.empty());
+
+            // when
+            final Exception result = catchException(
+                () -> orderUseCase.cancelOrder(orderId, userId));
+
+            // then
+            assertThat(result).isInstanceOf(DoesNotFindOrderException.class);
+        }
+    }
 }

--- a/payment/payment-domain/src/main/java/shop/woowasap/payment/domain/out/PaymentRepository.java
+++ b/payment/payment-domain/src/main/java/shop/woowasap/payment/domain/out/PaymentRepository.java
@@ -1,11 +1,11 @@
 package shop.woowasap.payment.domain.out;
 
-import java.util.List;
+import java.util.Optional;
 import shop.woowasap.payment.domain.Payment;
 
 public interface PaymentRepository {
 
     Payment save(final Payment payment);
 
-    List<Payment> findAllByOrderId(final long orderId);
+    Optional<Payment> findByOrderId(final long orderId);
 }

--- a/payment/payment-domain/src/test/java/shop/woowasap/payment/domain/PaymentTest.java
+++ b/payment/payment-domain/src/test/java/shop/woowasap/payment/domain/PaymentTest.java
@@ -1,0 +1,31 @@
+package shop.woowasap.payment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import shop.woowasap.payment.domain.support.PaymentFixture;
+
+@DisplayName("Payment 클래스")
+class PaymentTest {
+
+    @Nested
+    @DisplayName("changeStatus 메소드는")
+    class changeStatusMethod {
+
+        @Test
+        @DisplayName("PayStatus를 받아서, 상태를 변경한다.")
+        void changeStatusWhenReceivePayStatus() {
+            // given
+            final Payment payment = PaymentFixture.defaultPayment();
+
+            // when
+            final Payment result = payment.changeStatus(PayStatus.CANCELED);
+
+            // then
+            assertThat(result.getPayStatus()).isEqualTo(PayStatus.CANCELED);
+        }
+    }
+}

--- a/payment/payment-domain/src/test/java/shop/woowasap/payment/domain/support/PaymentFixture.java
+++ b/payment/payment-domain/src/test/java/shop/woowasap/payment/domain/support/PaymentFixture.java
@@ -1,0 +1,28 @@
+package shop.woowasap.payment.domain.support;
+
+import java.math.BigInteger;
+import shop.woowasap.payment.domain.PayStatus;
+import shop.woowasap.payment.domain.PayType;
+import shop.woowasap.payment.domain.Payment;
+
+public final class PaymentFixture {
+
+    private static final long DEFAULT_ORDER_ID = 1L;
+    private static final long DEFAULT_USER_ID = 1L;
+
+    private PaymentFixture() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static Payment defaultPayment() {
+        return Payment.builder()
+            .paymentId(1234L)
+            .orderId(DEFAULT_ORDER_ID)
+            .userId(DEFAULT_USER_ID)
+            .purchasedMoney(BigInteger.valueOf(10000))
+            .payType(PayType.CARD)
+            .payStatus(PayStatus.PENDING)
+            .build();
+    }
+
+}

--- a/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/PaymentRepositoryImpl.java
+++ b/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/PaymentRepositoryImpl.java
@@ -1,6 +1,6 @@
 package shop.woowasap.payment.repository;
 
-import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import shop.woowasap.payment.domain.Payment;
@@ -22,9 +22,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
-    public List<Payment> findAllByOrderId(final long orderId) {
-        final List<PaymentEntity> result = paymentEntityRepository.findByOrderIdOrderByUpdatedAtDesc(
-            orderId);
-        return result.stream().map(PaymentEntityMapper::toDomain).toList();
+    public Optional<Payment> findByOrderId(final long orderId) {
+        return paymentEntityRepository.findByOrderId(orderId).map(PaymentEntityMapper::toDomain);
     }
 }

--- a/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/jpa/PaymentEntityRepository.java
+++ b/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/jpa/PaymentEntityRepository.java
@@ -1,10 +1,13 @@
 package shop.woowasap.payment.repository.jpa;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.woowasap.payment.repository.entity.PaymentEntity;
 
 public interface PaymentEntityRepository extends JpaRepository<PaymentEntity, Long> {
 
     List<PaymentEntity> findByOrderIdOrderByUpdatedAtDesc(final long orderId);
+
+    Optional<PaymentEntity> findByOrderId(long orderId);
 }

--- a/payment/payment-repository/src/test/java/shop/woowasap/payment/repository/PaymentRepositoryImplTest.java
+++ b/payment/payment-repository/src/test/java/shop/woowasap/payment/repository/PaymentRepositoryImplTest.java
@@ -1,24 +1,20 @@
 package shop.woowasap.payment.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import shop.woowasap.BeanScanBaseLocation;
 import shop.woowasap.payment.domain.PayStatus;
 import shop.woowasap.payment.domain.PayType;
 import shop.woowasap.payment.domain.Payment;
-import shop.woowasap.payment.repository.entity.PaymentEntity;
 import shop.woowasap.payment.repository.jpa.PaymentEntityRepository;
 
 @DataJpaTest
@@ -29,7 +25,7 @@ class PaymentRepositoryImplTest {
     @Autowired
     private PaymentRepositoryImpl paymentRepository;
 
-    @MockBean
+    @Autowired
     private PaymentEntityRepository paymentEntityRepository;
 
     @Nested
@@ -50,9 +46,6 @@ class PaymentRepositoryImplTest {
                 .payStatus(PayStatus.SUCCESS)
                 .createdAt(instant)
                 .build();
-            final PaymentEntity entity = PaymentEntityMapper.toEntity(payment);
-
-            when(paymentEntityRepository.save(any())).thenReturn(entity);
 
             // when
             final Payment result = paymentRepository.save(payment);
@@ -65,7 +58,7 @@ class PaymentRepositoryImplTest {
     }
 
     @Nested
-    @DisplayName("findAllByOrderId 메소드")
+    @DisplayName("findByOrderId 메소드")
     class FindByOrderIdMethod {
 
         @Test
@@ -82,16 +75,15 @@ class PaymentRepositoryImplTest {
                 .payStatus(PayStatus.SUCCESS)
                 .createdAt(instant)
                 .build();
-            final PaymentEntity entity = PaymentEntityMapper.toEntity(payment);
 
-            when(paymentEntityRepository.findByOrderIdOrderByUpdatedAtDesc(12L)).thenReturn(
-                List.of(entity));
+            paymentRepository.save(payment);
 
             // when
-            final List<Payment> result = paymentRepository.findAllByOrderId(12L);
+            final Optional<Payment> result = paymentRepository.findByOrderId(12L);
 
             // then
-            assertThat(result.get(0)).usingRecursiveComparison().ignoringFields("createdAt")
+            assertThat(result).isPresent();
+            assertThat(result.get()).usingRecursiveComparison().ignoringFields("createdAt")
                 .isEqualTo(payment);
         }
     }

--- a/payment/payment-service/src/main/java/shop/woowasap/payment/service/PaymentEventService.java
+++ b/payment/payment-service/src/main/java/shop/woowasap/payment/service/PaymentEventService.java
@@ -1,0 +1,29 @@
+package shop.woowasap.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.woowasap.order.domain.out.event.OrderCanceledEvent;
+import shop.woowasap.payment.domain.PayStatus;
+import shop.woowasap.payment.domain.Payment;
+import shop.woowasap.payment.domain.exception.DoesNotFindPaymentException;
+import shop.woowasap.payment.domain.out.PaymentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentEventService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    @EventListener(OrderCanceledEvent.class)
+    public void cancelPay(final OrderCanceledEvent orderCanceledEvent) {
+        final Payment payment = paymentRepository.findByOrderId(orderCanceledEvent.orderId())
+            .orElseThrow(() -> new DoesNotFindPaymentException(orderCanceledEvent.orderId()));
+
+        payment.changeStatus(PayStatus.CANCELED);
+
+        paymentRepository.save(payment);
+    }
+}

--- a/payment/payment-service/src/main/java/shop/woowasap/payment/service/PaymentService.java
+++ b/payment/payment-service/src/main/java/shop/woowasap/payment/service/PaymentService.java
@@ -73,11 +73,10 @@ public class PaymentService implements PaymentUseCase {
     }
 
     private void validateDuplicatedPay(final PaymentRequest paymentRequest) {
-        paymentRepository.findAllByOrderId(paymentRequest.orderId()).forEach(payment -> {
-            if (!payment.getPayStatus().equals(PayStatus.FAIL)) {
-                throw new DuplicatedPayException(paymentRequest.orderId());
-            }
-        });
+        paymentRepository.findByOrderId(paymentRequest.orderId())
+            .ifPresent(payment -> {
+                throw new DuplicatedPayException(payment.getOrderId());
+            });
     }
 
     private Payment buildPayment(final PaymentRequest paymentRequest, final Order order) {

--- a/payment/payment-service/src/test/java/shop/woowasap/payment/service/PaymentEventServiceTest.java
+++ b/payment/payment-service/src/test/java/shop/woowasap/payment/service/PaymentEventServiceTest.java
@@ -1,0 +1,71 @@
+package shop.woowasap.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import shop.woowasap.order.domain.out.event.OrderCanceledEvent;
+import shop.woowasap.payment.domain.Payment;
+import shop.woowasap.payment.domain.exception.DoesNotFindPaymentException;
+import shop.woowasap.payment.domain.out.PaymentRepository;
+import shop.woowasap.payment.service.support.PaymentFixture;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("PaymentEventServiceTest 클래스")
+@ContextConfiguration(classes = PaymentEventService.class)
+class PaymentEventServiceTest {
+
+    @Autowired
+    private PaymentEventService paymentEventService;
+
+    @MockBean
+    private PaymentRepository paymentRepository;
+
+    @Nested
+    @DisplayName("cancelPay 메소드는")
+    class cancelPayMethod {
+
+        @Test
+        @DisplayName("OrderCanceledEvent 를 받아, 주문id에 해당하는 결제를 취소한다.")
+        void cancelPayWhenReceiveOrderCanceledEvent() {
+            // given
+            final OrderCanceledEvent orderCanceledEvent = new OrderCanceledEvent(1L);
+
+            when(paymentRepository.findByOrderId(orderCanceledEvent.orderId())).thenReturn(
+                Optional.of(PaymentFixture.defaultPayment()));
+
+            // when
+            final Exception result = catchException(
+                () -> paymentEventService.cancelPay(orderCanceledEvent));
+
+            // then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("orderId에 해당하는 Pay를 찾을 수 없는경우, DoesNotFindPaymentException를 던진다.")
+        void throwDoesNotFindPaymentExceptionWhenCannotFindPayByOrderId() {
+            // given
+            final OrderCanceledEvent orderCanceledEvent = new OrderCanceledEvent(1L);
+
+            when(paymentRepository.findByOrderId(orderCanceledEvent.orderId())).thenReturn(
+                Optional.empty());
+
+            // when
+            final Exception result = catchException(
+                () -> paymentEventService.cancelPay(orderCanceledEvent));
+
+            // then
+            assertThat(result).isInstanceOf(DoesNotFindPaymentException.class);
+        }
+    }
+}

--- a/payment/payment-service/src/test/java/shop/woowasap/payment/service/PaymentServiceTest.java
+++ b/payment/payment-service/src/test/java/shop/woowasap/payment/service/PaymentServiceTest.java
@@ -99,7 +99,7 @@ class PaymentServiceTest {
                 Optional.of(order));
             when(idGenerator.generate()).thenReturn(1L);
             when(timeUtil.now()).thenReturn(instant.plusMillis(100L));
-            when(paymentRepository.findAllByOrderId(anyLong())).thenReturn(List.of());
+            when(paymentRepository.findByOrderId(anyLong())).thenReturn(Optional.empty());
             when(paymentRepository.save(any())).thenReturn(payment);
 
             // when
@@ -147,9 +147,7 @@ class PaymentServiceTest {
                 Optional.of(order));
             when(idGenerator.generate()).thenReturn(1L);
             when(timeUtil.now()).thenReturn(instant.plusMillis(100L));
-            when(paymentRepository.findAllByOrderId(anyLong())).thenReturn(List.of(
-                Payment.builder().payStatus(PayStatus.FAIL).build()
-            ));
+            when(paymentRepository.findByOrderId(anyLong())).thenReturn(Optional.empty());
             when(paymentRepository.save(any())).thenReturn(payment);
 
             // when
@@ -247,7 +245,7 @@ class PaymentServiceTest {
                 Optional.of(order));
             when(idGenerator.generate()).thenReturn(1L);
             when(timeUtil.now()).thenReturn(instant.plusMillis(100L));
-            when(paymentRepository.findAllByOrderId(anyLong())).thenReturn(List.of(
+            when(paymentRepository.findByOrderId(anyLong())).thenReturn(Optional.of(
                 Payment.builder().payStatus(PayStatus.SUCCESS).build()
             ));
 
@@ -296,7 +294,7 @@ class PaymentServiceTest {
                 Optional.of(order));
             when(idGenerator.generate()).thenReturn(1L);
             when(timeUtil.now()).thenReturn(instant.plusMillis(100L));
-            when(paymentRepository.findAllByOrderId(anyLong())).thenReturn(List.of());
+            when(paymentRepository.findByOrderId(anyLong())).thenReturn(Optional.empty());
             when(paymentRepository.save(any())).thenReturn(payment);
             doThrow(DoesNotOrderedException.class).when(orderConnector)
                 .consumeStock(order.getId(), order.getUserId());

--- a/payment/payment-service/src/test/java/shop/woowasap/payment/service/support/PaymentFixture.java
+++ b/payment/payment-service/src/test/java/shop/woowasap/payment/service/support/PaymentFixture.java
@@ -1,0 +1,28 @@
+package shop.woowasap.payment.service.support;
+
+import java.math.BigInteger;
+import shop.woowasap.payment.domain.PayStatus;
+import shop.woowasap.payment.domain.PayType;
+import shop.woowasap.payment.domain.Payment;
+
+public final class PaymentFixture {
+
+    private static final long DEFAULT_ORDER_ID = 1L;
+    private static final long DEFAULT_USER_ID = 1L;
+
+    private PaymentFixture() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static Payment defaultPayment() {
+        return Payment.builder()
+            .paymentId(1234L)
+            .orderId(DEFAULT_ORDER_ID)
+            .userId(DEFAULT_USER_ID)
+            .purchasedMoney(BigInteger.valueOf(10000))
+            .payType(PayType.CARD)
+            .payStatus(PayStatus.PENDING)
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 🚀 어떤 기능을 개발했나요?
주문과 결제 취소 서비스를 구현했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 주문 취소 서비스 구현
- [x] 주문 취소 이벤트 구현
- [x] 결제 취소 서비스 구현

## 🦀 이슈 넘버
- resolve #255

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
