### PR TITLE
refactor: 재결제 로직 수정

### DIFF
--- a/payment/payment-domain/src/main/java/shop/woowasap/payment/domain/in/response/PaymentResponse.java
+++ b/payment/payment-domain/src/main/java/shop/woowasap/payment/domain/in/response/PaymentResponse.java
@@ -1,14 +1,7 @@
 package shop.woowasap.payment.domain.in.response;
 
 public record PaymentResponse(
-    Boolean isSuccess
+    String payStatus
 ) {
 
-    public static PaymentResponse success() {
-        return new PaymentResponse(true);
-    }
-
-    public static PaymentResponse fail() {
-        return new PaymentResponse(false);
-    }
 }

--- a/payment/payment-domain/src/main/java/shop/woowasap/payment/domain/out/PaymentRepository.java
+++ b/payment/payment-domain/src/main/java/shop/woowasap/payment/domain/out/PaymentRepository.java
@@ -1,5 +1,6 @@
 package shop.woowasap.payment.domain.out;
 
+import java.util.List;
 import java.util.Optional;
 import shop.woowasap.payment.domain.Payment;
 
@@ -8,4 +9,6 @@ public interface PaymentRepository {
     Payment save(final Payment payment);
 
     Optional<Payment> findByOrderId(final long orderId);
+
+    List<Payment> findAllByOrderId(final long orderId);
 }

--- a/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/PaymentRepositoryImpl.java
+++ b/payment/payment-repository/src/main/java/shop/woowasap/payment/repository/PaymentRepositoryImpl.java
@@ -1,5 +1,6 @@
 package shop.woowasap.payment.repository;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -24,5 +25,12 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public Optional<Payment> findByOrderId(final long orderId) {
         return paymentEntityRepository.findByOrderId(orderId).map(PaymentEntityMapper::toDomain);
+    }
+
+    @Override
+    public List<Payment> findAllByOrderId(final long orderId) {
+        return paymentEntityRepository.findByOrderIdOrderByUpdatedAtDesc(orderId).stream()
+            .map(PaymentEntityMapper::toDomain)
+            .toList();
     }
 }

--- a/payment/payment-repository/src/test/java/shop/woowasap/payment/repository/PaymentRepositoryImplTest.java
+++ b/payment/payment-repository/src/test/java/shop/woowasap/payment/repository/PaymentRepositoryImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -84,6 +85,36 @@ class PaymentRepositoryImplTest {
             // then
             assertThat(result).isPresent();
             assertThat(result.get()).usingRecursiveComparison().ignoringFields("createdAt")
+                .isEqualTo(payment);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByOrderId 메소드")
+    class FindAllByOrderIdMethod {
+
+        @Test
+        @DisplayName("정상 입력시 객체 반환")
+        void findSuccess() {
+            // given
+            final Instant instant = Instant.parse("2023-08-15T00:00:02.00Z");
+            final Payment payment = Payment.builder()
+                .paymentId(1L)
+                .orderId(12L)
+                .userId(123L)
+                .purchasedMoney(BigInteger.valueOf(10000L))
+                .payType(PayType.CARD)
+                .payStatus(PayStatus.SUCCESS)
+                .createdAt(instant)
+                .build();
+
+            paymentRepository.save(payment);
+
+            // when
+            final List<Payment> result = paymentRepository.findAllByOrderId(12L);
+
+            // then
+            assertThat(result.get(0)).usingRecursiveComparison().ignoringFields("createdAt")
                 .isEqualTo(payment);
         }
     }


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
재결제 로직 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] PaymentResponse 수정
- [x] 결제에서 재결제 가능하게 수정

## 🦀 이슈 넘버
- #253 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
