### PR TITLE
refactor: 주문 내역 리스트에서 OrderId 역순으로 정렬 및 주문 타입 추가

### DIFF
--- a/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
+++ b/app/src/test/java/shop/woowasap/accept/OrderAcceptanceTest.java
@@ -100,7 +100,7 @@ class OrderAcceptanceTest extends AcceptanceTest {
             product.productId(), product.name(), product.price(), quantity);
         final OrderResponse expectedOrderResponse = new OrderResponse(1L,
             List.of(expectedOrderProductResponse),
-            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(),
+            new BigInteger(product.price()).multiply(BigInteger.valueOf(quantity)).toString(), "PENDING",
             LocalDateTime.now());
         final OrdersResponse expected = new OrdersResponse(List.of(expectedOrderResponse), 1, 1);
 

--- a/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderResponse.java
+++ b/order/order-domain/src/main/java/shop/woowasap/order/domain/in/response/OrderResponse.java
@@ -4,6 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record OrderResponse(long orderId, List<OrderProductResponse> products, String totalPrice,
-                            LocalDateTime createdAt) {
+                            String type, LocalDateTime createdAt) {
 
 }

--- a/order/order-repository/src/main/java/shop/woowasap/order/repository/OrderRepositoryImpl.java
+++ b/order/order-repository/src/main/java/shop/woowasap/order/repository/OrderRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import shop.woowasap.order.domain.Order;
 import shop.woowasap.order.domain.out.OrderRepository;
@@ -26,7 +27,7 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public OrdersPaginationResponse findAllOrderByUserId(final long userId, final int page,
         final int size) {
-        final PageRequest pageRequest = PageRequest.of(page - 1, size);
+        final PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by("id").descending());
         final Page<OrderEntity> pagination = orderJpaRepository.findAllByUserId(userId, pageRequest);
 
         final List<Order> orders = pagination.get()

--- a/order/order-repository/src/test/java/shop/woowasap/order/repository/OrderRepositoryImplTest.java
+++ b/order/order-repository/src/test/java/shop/woowasap/order/repository/OrderRepositoryImplTest.java
@@ -104,7 +104,7 @@ class OrderRepositoryImplTest {
             final int size = 1;
 
             final OrdersPaginationResponse expected = new OrdersPaginationResponse(
-                List.of(firstOrder), page, 2);
+                List.of(secondOrder), page, 2);
 
             // when
             final OrdersPaginationResponse result = orderRepository.findAllOrderByUserId(
@@ -132,7 +132,7 @@ class OrderRepositoryImplTest {
             final int size = 2;
 
             final OrdersPaginationResponse expected = new OrdersPaginationResponse(
-                List.of(firstOrder, secondOrder), page, 1);
+                List.of(secondOrder, firstOrder), page, 1);
 
             // when
             final OrdersPaginationResponse result = orderRepository.findAllOrderByUserId(

--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderService.java
@@ -2,7 +2,6 @@ package shop.woowasap.order.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,9 +41,6 @@ public class OrderService implements OrderUseCase {
     private final TimeUtil timeUtil;
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @Value("${shop.woowasap.locale:UTC}")
-    private String locale;
-
     @Override
     @Transactional
     public OrderIdResponse orderProduct(final OrderProductRequest orderProductRequest) {
@@ -82,8 +78,7 @@ public class OrderService implements OrderUseCase {
         final List<Order> orders = ordersPaginationResponse.orders();
 
         final List<OrderResponse> orderResponses = orders.stream()
-            .map(
-                order -> OrderMapper.toOrderResponse(order, getOrderProductResponse(order), locale))
+            .map(order -> OrderMapper.toOrderResponse(order, getOrderProductResponse(order)))
             .toList();
 
         return OrderMapper.toOrdersResponse(orderResponses, ordersPaginationResponse.page(),
@@ -118,6 +113,6 @@ public class OrderService implements OrderUseCase {
             .map(OrderMapper::toDetailOrderProductResponse)
             .toList();
 
-        return OrderMapper.toDetailOrderResponse(order, detailOrderProductResponses, locale);
+        return OrderMapper.toDetailOrderResponse(order, detailOrderProductResponses);
     }
 }

--- a/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/mapper/OrderMapper.java
@@ -72,11 +72,11 @@ public final class OrderMapper {
     }
 
     public static OrderResponse toOrderResponse(final Order order,
-        final List<OrderProductResponse> orderProductResponses, final String locale) {
+        final List<OrderProductResponse> orderProductResponses) {
 
         return new OrderResponse(order.getId(), orderProductResponses,
-            order.getTotalPrice().toString(),
-            LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
+            order.getTotalPrice().toString(), order.getOrderType().toString(),
+            LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of("UTC")));
     }
 
     public static OrdersResponse toOrdersResponse(final List<OrderResponse> orderResponses,
@@ -86,11 +86,11 @@ public final class OrderMapper {
     }
 
     public static DetailOrderResponse toDetailOrderResponse(final Order order,
-        final List<DetailOrderProductResponse> detailOrderProductResponses, final String locale) {
+        final List<DetailOrderProductResponse> detailOrderProductResponses) {
 
         return new DetailOrderResponse(order.getId(), detailOrderProductResponses,
             order.getTotalPrice().toString(), order.getOrderType().toString(),
-            LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale)));
+            LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of("UTC")));
     }
 
     public static DetailOrderProductResponse toDetailOrderProductResponse(

--- a/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
+++ b/order/order-service/src/test/java/shop/woowasap/order/service/support/fixture/OrderDtoFixture.java
@@ -31,7 +31,9 @@ public final class OrderDtoFixture {
         return orders.stream()
             .map(order -> new OrderResponse(order.getId(),
                 getOrderProductResponse(order, fixedName, fixedPrice),
-                order.getTotalPrice().toString(), LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale))))
+                order.getTotalPrice().toString(),
+                order.getOrderType().toString(),
+                LocalDateTime.ofInstant(order.getCreatedAt(), ZoneId.of(locale))))
             .toList();
     }
 


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

주문 내역 리스트에서 OrderId 역순으로 정렬 및 주문 타입을 추가했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] OrderRepositoryImpl 에서 id 기준으로 내림차순으로 정렬하도록 수정
- [x] OrderResponse 에 type 추가 

## 🦀 이슈 넘버

- close #276 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
