### PR TITLE
fix: `consume stock`에서 `DoesNotOrderedException` 롤백 방지

### DIFF
--- a/order/order-service/src/main/java/shop/woowasap/order/service/OrderConnectorService.java
+++ b/order/order-service/src/main/java/shop/woowasap/order/service/OrderConnectorService.java
@@ -29,7 +29,7 @@ public class OrderConnectorService implements OrderConnector {
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = DoesNotOrderedException.class)
     public void consumeStock(final long orderId, final long userId) {
         final Order order = getOrder(orderId, userId);
         try {


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
`consume stock`에서 `DoesNotOrderedException` 롤백을 방지했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] `consumeStock()` 메소드에서, DoesNotOrderedException을 롤백시키지 않도록 수정

## 🦀 이슈 넘버
- close #284 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
