### PR TITLE
fix: Product의 재고가 0인 경우, Cart에 담기는 경우 예외처리 추가

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProductQuantity.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/cart/CartProductQuantity.java
@@ -4,6 +4,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import shop.woowasap.shop.domain.exception.InvalidCartProductQuantityException;
+import shop.woowasap.shop.domain.exception.InvalidProductQuantityException;
 import shop.woowasap.shop.domain.product.Quantity;
 
 @Getter
@@ -16,7 +17,7 @@ public final class CartProductQuantity {
     private final Long value;
 
     public CartProductQuantity(final Long value, final Quantity quantity) {
-        validate(value);
+        validate(value, quantity.getValue());
         this.value = getBoundValue(value, quantity.getValue());
     }
 
@@ -24,9 +25,12 @@ public final class CartProductQuantity {
         this(value, new Quantity(MAX_CART_PRODUCT_QUANTITY));
     }
 
-    private void validate(final Long value) {
+    private void validate(final Long value, final long productQuantity) {
         if (value == null) {
             throw new InvalidCartProductQuantityException("해당 장바구니의 상품 수량이 입력이 잘못되었습니다.");
+        }
+        if (productQuantity <= 0) {
+            throw new InvalidProductQuantityException("해당 상품 수량이 부족해서 구매할 수 없습니다.");
         }
     }
 

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartProductTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/cart/CartProductTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchException;
 import static shop.woowasap.shop.domain.support.CartFixture.getCartProductBuilder;
+import static shop.woowasap.shop.domain.support.ProductFixture.getDefaultBuilder;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import shop.woowasap.shop.domain.exception.InvalidCartProductQuantityException;
+import shop.woowasap.shop.domain.exception.InvalidProductQuantityException;
 import shop.woowasap.shop.domain.product.Product;
 import shop.woowasap.shop.domain.support.ProductFixture;
 
@@ -41,6 +43,20 @@ class CartProductTest {
 
             // then
             assertThat(exception).isInstanceOf(InvalidCartProductQuantityException.class);
+        }
+
+        @Test
+        @DisplayName("해당 상품의 재고가 없는 경우에 장바구니에 담으려는 경우,예외를 던진다.")
+        void addCartProductWithZero() {
+            // given
+            final Product product = getDefaultBuilder().quantity(0L).build();
+
+            // when
+            final Exception exception = catchException(
+                () -> getCartProductBuilder(product, 10L).build());
+
+            // when
+            assertThat(exception).isInstanceOf(InvalidProductQuantityException.class);
         }
 
         @Test


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

Product의 재고가 0인 경우, Cart에 담기는 경우 예외처리 추가했습니다.

## 🕶️ 어떻게 해결했나요?

- [x] product quantity도 함께 validate 하도록 수정

## 🦀 이슈 넘버

- close #287 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
