### PR TITLE
feat: 상품이 등록되거나 수정될 때 Redis Cache 초기화

### DIFF
--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductService.java
@@ -54,9 +54,9 @@ public class ProductService implements ProductUseCase {
         productRepository.persist(updateProduct);
     }
 
-    @CacheEvict(value = "products", allEntries = true, cacheManager = "cacheManager")
     @Override
     @Transactional
+    @CacheEvict(value = "products", allEntries = true, cacheManager = "cacheManager")
     public Long registerProduct(final RegisterProductRequest registerProductRequest) {
         final Product persistProduct = productRepository.persist(
             toDomain(idGenerator, registerProductRequest, timeUtil.now()));

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductService.java
@@ -6,6 +6,7 @@ import static shop.woowasap.shop.service.mapper.ProductMapper.toProductsAdminRes
 import java.text.MessageFormat;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +37,7 @@ public class ProductService implements ProductUseCase {
 
     @Override
     @Transactional
+    @CacheEvict(value = "products", allEntries = true, cacheManager = "cacheManager")
     public void update(final long productId, final UpdateProductRequest updateProductRequest) {
         final Product product = getProduct(productId);
 
@@ -52,6 +54,7 @@ public class ProductService implements ProductUseCase {
         productRepository.persist(updateProduct);
     }
 
+    @CacheEvict(value = "products", allEntries = true, cacheManager = "cacheManager")
     @Override
     @Transactional
     public Long registerProduct(final RegisterProductRequest registerProductRequest) {


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 상품이 등록되거나 수정될 때 Redis Cache를 초기화한다

## 🕶️ 어떻게 해결했나요?
- [x] 상품 등록과 상품 수정 서비스에 `CacheEvict`  를 설정한다

## 🦀 이슈 넘버
- close #289 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
