### PR TITLE
fix: 상품 수정 요청 시, startTime 과 endTime 검증 로직 추가

### DIFF
--- a/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/product/Product.java
+++ b/shop/shop-domain/src/main/java/shop/woowasap/shop/domain/product/Product.java
@@ -2,8 +2,6 @@ package shop.woowasap.shop.domain.product;
 
 import java.text.MessageFormat;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -53,8 +51,7 @@ public final class Product {
         final String description,
         final String price,
         final long quantity,
-        final LocalDateTime startTime,
-        final LocalDateTime endTime,
+        final SaleTime saleTime,
         final Instant nowTime
     ) {
         validateUpdateTime(nowTime);
@@ -65,11 +62,7 @@ public final class Product {
             .description(description)
             .price(price)
             .quantity(quantity)
-            .saleTime(SaleTime.builder()
-                .startTime(startTime.atZone(ZoneOffset.UTC).toInstant())
-                .endTime(endTime.atZone(ZoneOffset.UTC).toInstant())
-                .nowTime(nowTime)
-                .build())
+            .saleTime(saleTime)
             .build();
     }
 

--- a/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/ProductTest.java
+++ b/shop/shop-domain/src/test/java/shop/woowasap/shop/domain/product/ProductTest.java
@@ -232,8 +232,17 @@ class ProductTest {
                 .build();
 
             // when
-            final Product update = original.update(name, description, price, quantity, startTime,
-                endTime, updateTime);
+            final Product update = original.update(
+                name,
+                description,
+                price,
+                quantity,
+                SaleTime.builder()
+                    .startTime(startTime.toInstant(ZoneOffset.UTC))
+                    .endTime(endTime.toInstant(ZoneOffset.UTC))
+                    .build(),
+                updateTime
+            );
 
             // then
             assertThat(update).usingRecursiveAssertion().isEqualTo(expected);
@@ -265,12 +274,19 @@ class ProductTest {
 
             // when
             final Exception exception = catchException(
-                () -> original.update(name, description, price, quantity, startTime, endTime,
+                () -> original.update(
+                    name,
+                    description,
+                    price,
+                    quantity,
+                    SaleTime.builder()
+                        .startTime(startTime.toInstant(ZoneOffset.UTC))
+                        .endTime(endTime.toInstant(ZoneOffset.UTC))
+                        .build(),
                     updateTime));
 
             // then
             assertThat(exception).isInstanceOf(ProductModificationPermissionException.class);
-
         }
     }
 

--- a/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
+++ b/shop/shop-repository/src/test/java/shop/woowasap/shop/repository/ProductRepositoryImplTest.java
@@ -6,8 +6,6 @@ import static shop.woowasap.shop.repository.support.ProductFixture.beforeSalePro
 import static shop.woowasap.shop.repository.support.ProductFixture.onSaleProduct;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +18,7 @@ import shop.woowasap.BeanScanBaseLocation;
 import shop.woowasap.shop.domain.out.response.ProductsPaginationAdminResponse;
 import shop.woowasap.shop.domain.out.response.ProductsPaginationResponse;
 import shop.woowasap.shop.domain.product.Product;
+import shop.woowasap.shop.domain.product.SaleTime;
 
 @DataJpaTest
 @ContextConfiguration(classes = {BeanScanBaseLocation.class, ProductRepositoryImpl.class})
@@ -60,9 +59,11 @@ class ProductRepositoryImplTest {
                 product.getDescription().getValue(),
                 product.getPrice().getValue().toString(),
                 product.getQuantity().getValue(),
-                LocalDateTime.ofInstant(product.getSaleTime().getStartTime(), ZoneId.of("UTC")),
-                LocalDateTime.ofInstant(product.getSaleTime().getEndTime(), ZoneId.of("UTC")),
-                Instant.parse("2023-08-01T00:00:00.000Z")
+                SaleTime.builder()
+                    .startTime(product.getSaleTime().getStartTime())
+                    .endTime(product.getSaleTime().getEndTime())
+                    .build()
+                , Instant.parse("2023-08-01T01:00:00.000Z")
             );
 
             final Product result = productRepository.persist(product);

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductService.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/ProductService.java
@@ -1,7 +1,8 @@
 package shop.woowasap.shop.service;
 
-import static shop.woowasap.shop.service.mapper.ProductMapper.toDomain;
 import static shop.woowasap.shop.service.mapper.ProductMapper.toProductsAdminResponse;
+import static shop.woowasap.shop.service.mapper.ProductMapper.toRegisterProduct;
+import static shop.woowasap.shop.service.mapper.ProductMapper.toUpdateProduct;
 
 import java.text.MessageFormat;
 import java.time.Instant;
@@ -39,24 +40,14 @@ public class ProductService implements ProductUseCase {
     public void update(final long productId, final UpdateProductRequest updateProductRequest) {
         final Product product = getProduct(productId);
 
-        final Product updateProduct = product.update(
-            updateProductRequest.name(),
-            updateProductRequest.description(),
-            updateProductRequest.price(),
-            updateProductRequest.quantity(),
-            updateProductRequest.startTime(),
-            updateProductRequest.endTime(),
-            timeUtil.now()
-        );
-
-        productRepository.persist(updateProduct);
+        productRepository.persist(toUpdateProduct(product, updateProductRequest, timeUtil.now()));
     }
 
     @Override
     @Transactional
     public Long registerProduct(final RegisterProductRequest registerProductRequest) {
         final Product persistProduct = productRepository.persist(
-            toDomain(idGenerator, registerProductRequest, timeUtil.now()));
+            toRegisterProduct(idGenerator, registerProductRequest, timeUtil.now()));
 
         return persistProduct.getId();
     }

--- a/shop/shop-service/src/main/java/shop/woowasap/shop/service/mapper/ProductMapper.java
+++ b/shop/shop-service/src/main/java/shop/woowasap/shop/service/mapper/ProductMapper.java
@@ -7,6 +7,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import shop.woowasap.core.id.api.IdGenerator;
 import shop.woowasap.shop.domain.in.product.request.RegisterProductRequest;
+import shop.woowasap.shop.domain.in.product.request.UpdateProductRequest;
 import shop.woowasap.shop.domain.in.product.response.ProductDetailsResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductResponse;
 import shop.woowasap.shop.domain.in.product.response.ProductsAdminResponse;
@@ -23,7 +24,23 @@ public final class ProductMapper {
     private ProductMapper() {
     }
 
-    public static Product toDomain(final IdGenerator idGenerator,
+    public static Product toUpdateProduct(final Product product,
+        final UpdateProductRequest updateProductRequest, final Instant nowTime) {
+        return product.update(
+            updateProductRequest.name(),
+            updateProductRequest.description(),
+            updateProductRequest.price(),
+            updateProductRequest.quantity(),
+            SaleTime.builder()
+                .startTime(updateProductRequest.startTime().toInstant(ZoneOffset.UTC))
+                .endTime(updateProductRequest.endTime().toInstant(ZoneOffset.UTC))
+                .nowTime(nowTime)
+                .build(),
+            nowTime
+        );
+    }
+
+    public static Product toRegisterProduct(final IdGenerator idGenerator,
         final RegisterProductRequest registerProductRequest, final Instant nowTime) {
         return Product.builder()
             .id(idGenerator.generate())

--- a/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductServiceTest.java
+++ b/shop/shop-service/src/test/java/shop/woowasap/shop/service/ProductServiceTest.java
@@ -135,9 +135,13 @@ class ProductServiceTest {
             // given
             final long onSaleProductId = 1L;
             final Product product = onSaleProduct(onSaleProductId);
-            final UpdateProductRequest updateProductRequest = updateProductRequest(product);
+            final Product updateProduct = beforeSaleProduct(onSaleProductId);
+            final Instant updateTime = Instant.parse("2023-08-01T02:00:00.000Z");
+            final UpdateProductRequest updateProductRequest = updateProductRequest(updateProduct);
 
-            when(productRepository.findById(onSaleProductId)).thenReturn(Optional.of(product));
+            when(productRepository.findById(onSaleProductId)).thenReturn(
+                Optional.of(product));
+            when(timeUtil.now()).thenReturn(updateTime);
 
             // when
             Exception exception = catchException(
@@ -223,7 +227,8 @@ class ProductServiceTest {
             final ProductsAdminResponse expectedProductsAdminResponse = productsResponse(products);
 
             // when
-            final ProductsAdminResponse productsAdminResponse = productService.getProductsInAdmin(page, size);
+            final ProductsAdminResponse productsAdminResponse = productService.getProductsInAdmin(
+                page, size);
 
             // then
             assertThat(productsAdminResponse).usingRecursiveComparison()
@@ -247,7 +252,8 @@ class ProductServiceTest {
 
             List<Product> products = List.of(product1, product2);
 
-            when(productRepository.findAllValidWithPagination(Instant.parse(startTime), productId, NOW_TIME)).thenReturn(
+            when(productRepository.findAllValidWithPagination(Instant.parse(startTime), productId,
+                NOW_TIME)).thenReturn(
                 new ProductsPaginationResponse(products, false));
 
             // when


### PR DESCRIPTION
<!--
	PR 타이틀 : 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 상품 수정 요청 시, 판매관련 시간인 startTime과 endTime 을 검증하는 로직을 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] Product update 시, SaleTime 을 생성해서 넘겨주는 과정에서 startTime과 endTime  검증하도록 수정

## 🦀 이슈 넘버
- close #291 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
